### PR TITLE
glibc: Use riscv.*- for shlib-versions CPU pattern

### DIFF
--- a/patches/glibc
+++ b/patches/glibc
@@ -14,7 +14,7 @@
  powerpc64-.*-linux.*	DEFAULT			GLIBC_2.3
  powerpc.*le-.*-linux.*	DEFAULT			GLIBC_2.17
  .*-.*-gnu-gnu.*		DEFAULT			GLIBC_2.2.6
-+riscv-.*-linux.*	DEFAULT			GLIBC_2.20
++riscv.*-.*-linux.*	DEFAULT			GLIBC_2.20
  
  # Configuration		Library=version		Earliest symbol set (optional)
  # -------------		---------------		------------------------------


### PR DESCRIPTION
The previous pattern matched `riscv-poky-linux-gnu` as intended but excluded `riscv64-unknown-linux-gnu`, which caused inconsistent symbol versioning with shared libraries.  In the former case, the explicit default of `GLIBC_2.20` imposes a more restrictive lower bound on the ABI, whereas in the latter, versioning follows the "earliest ABI" behavior.  This lack of compatibility becomes rather frustrating when using multiple toolchains together.
