### PR TITLE
glibc: Fix compile errors

### DIFF
--- a/glibc/sysdeps/riscv/fpu_control.h
+++ b/glibc/sysdeps/riscv/fpu_control.h
@@ -29,7 +29,7 @@
 #define _FPU_RESERVED 0xffffffff
 #define _FPU_DEFAULT  0x00000000
 typedef unsigned int fpu_control_t;
-#define _FPU_GETCW(cw) 0
+#define _FPU_GETCW(cw) (cw) = 0
 #define _FPU_SETCW(cw) do { } while (0)
 extern fpu_control_t __fpu_control;
 

--- a/glibc/sysdeps/unix/sysv/linux/riscv/bits/atomic.h
+++ b/glibc/sysdeps/unix/sysv/linux/riscv/bits/atomic.h
@@ -37,14 +37,14 @@
 #define __arch_compare_and_exchange_val_32_acq(mem, newval, oldval) \
   ({									      \
     INTERNAL_SYSCALL_DECL (__err);					      \
-    INTERNAL_SYSCALL (sysriscv, __err, 4,				      \
+    (__typeof (*mem)) INTERNAL_SYSCALL (sysriscv, __err, 4,		      \
 		      RISCV_ATOMIC_CMPXCHG, mem, oldval, newval);	      \
   })
 
 #define __arch_compare_and_exchange_val_64_acq(mem, newval, oldval) \
   ({									      \
     INTERNAL_SYSCALL_DECL (__err);					      \
-    INTERNAL_SYSCALL (sysriscv, __err, 4,				      \
+    (__typeof (*mem)) INTERNAL_SYSCALL (sysriscv, __err, 4,		      \
 		      RISCV_ATOMIC_CMPXCHG64, mem, oldval, newval);	      \
   })
 


### PR DESCRIPTION
Fix compile errors with -msoft-float and -mno-atomic that appear to have been introduced when updating to glibc 2.21