### PR TITLE
configure: Fix --enable-linux option.

### DIFF
--- a/configure
+++ b/configure
@@ -1261,7 +1261,8 @@ Optional Features:
   --disable-option-checking  ignore unrecognized --enable/--with options
   --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
-Toolchain targets Linux
+  --enable-linux          set linux as the default make target
+                          [--disable-linux]
 
 Some influential environment variables:
   CC          C compiler command
@@ -3091,14 +3092,20 @@ fi
 
 # Check whether --enable-linux was given.
 if test "${enable_linux+set}" = set; then :
-  enableval=$enable_linux; default_target=linux
+  enableval=$enable_linux;
+else
+  enable_linux=no
+
+fi
+
+
+if test "x$enable_linux" != xno; then :
+  default_target=linux
 
 else
   default_target=newlib
 
-
 fi
-
 
 ac_config_files="$ac_config_files Makefile"
 

--- a/configure.ac
+++ b/configure.ac
@@ -37,10 +37,15 @@ AS_IF([test x"$CURL" != xno], [FETCHER="$CURL -o - --ftp-pasv"],
 AC_SUBST(FETCHER)
 
 AC_ARG_ENABLE(linux,
-        [Toolchain targets Linux],
-        AC_SUBST(default_target, linux),
-        AC_SUBST(default_target, newlib)
+        [AS_HELP_STRING([--enable-linux],
+		[set linux as the default make target @<:@--disable-linux@:>@])],
+        [],
+        [enable_linux=no]
         )
+
+AS_IF([test "x$enable_linux" != xno],
+	[AC_SUBST(default_target, linux)],
+	[AC_SUBST(default_target, newlib)])
 
 AC_CONFIG_FILES([Makefile])
 AC_CONFIG_FILES([scripts/wrapper/awk], [chmod +x scripts/wrapper/awk])


### PR DESCRIPTION
Use AS_HELP_STRING to properly format help text.  Properly handle both
states of the option and the default.