### PR TITLE
binutils: Add RISC-V files to ALL_MACHINES{,_CFILES}

### DIFF
--- a/patches/binutils
+++ b/patches/binutils
@@ -533,3 +533,21 @@
  #ifdef ARCH_i386
    print_i386_disassembler_options (stream);
  #endif
+--- original-binutils/bfd/Makefile.in	2014-10-14 00:32:02.000000000 -0700
++++ binutils/bfd/Makefile.in	2015-03-31 06:53:23.253426230 -0700
+@@ -442,6 +442,7 @@
+ 	cpu-pj.lo \
+ 	cpu-plugin.lo \
+ 	cpu-powerpc.lo \
++	cpu-riscv.lo \
+ 	cpu-rs6000.lo \
+ 	cpu-rl78.lo \
+ 	cpu-rx.lo \
+@@ -526,6 +527,7 @@
+ 	cpu-pj.c \
+ 	cpu-plugin.c \
+ 	cpu-powerpc.c \
++	cpu-riscv.c \
+ 	cpu-rs6000.c \
+ 	cpu-rl78.c \
+ 	cpu-rx.c \


### PR DESCRIPTION
I've been getting sporadic binutils build failures for a while that
all look something like

  .../src/binutils/bfd/cpu-riscv.c:51:5: error: ‘bfd_arch_riscv’ undeclared here (not in a function)
       bfd_arch_riscv,     \
       ^
  ...
  Makefile:1605: recipe for target 'cpu-riscv.lo' failed
  make[6]: *** [cpu-riscv.lo] Error 1
  make[6]: *** Waiting for unfinished jobs....

I belive the problem here is that "bfd.h" is in the middle of being
generated while this build step is being run.  This can happen because
of a missing dependency, which you can verify by running

  $ cd build-binutils-linux/bfd
  $ rm stmp-bfd-h bfd.h cpu-riscv.lo
  $ make cpu-riscv.lo

which will fail because "bfd.h" doesn't get regenerated.  This patch
fixes that dependency problem by adding some RISC-V files to
ALL_MACHINES{,_CFILES}, which appears to be necessary to get the
dependency to work correctly (though I have no idea where it's coming
from).

It remains to be seen if this fixes the parellal build problem, but
this is certianly a bug.