### PR TITLE
Download GCC's libraries if they're not installed on the system

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -62,6 +62,7 @@ $(addprefix src/,$(PACKAGES)): src/%: src/original-%
 	cp -R $< $@.tmp
 	$(srcdir)/scripts/cp_s $(srcdir)/$(notdir $@) $@.tmp
 	cd $@.tmp && patch -p1 < $(srcdir)/patches/$(notdir $@)
+	if test -f $@.tmp/contrib/download_prerequisites && test "@NEED_GCC_EXTERNAL_LIBRARIES@" == "true"; then cd $@.tmp && ./contrib/download_prerequisites; fi
 	mv $@.tmp $@
 
 .PHONY: patches $(addprefix $(srcdir)/patches/,$(PACKAGES))

--- a/configure
+++ b/configure
@@ -595,6 +595,7 @@ FETCHER
 FTP
 WGET
 CURL
+NEED_GCC_EXTERNAL_LIBRARIES
 GSED
 GAWK
 BASH
@@ -2832,6 +2833,7 @@ fi
 GSED=$ac_cv_path_GSED
 
 
+need_gcc_external_libraries="no"
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for __gmpz_init in -lgmp" >&5
 $as_echo_n "checking for __gmpz_init in -lgmp... " >&6; }
@@ -2870,16 +2872,8 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_gmp___gmpz_init" >&5
 $as_echo "$ac_cv_lib_gmp___gmpz_init" >&6; }
 if test "x$ac_cv_lib_gmp___gmpz_init" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE_LIBGMP 1
-_ACEOF
-
-  LIBS="-lgmp $LIBS"
-
-else
-  as_fn_error $? "GNU MP not found; see https://gmplib.org/" "$LINENO" 5
+  need_gcc_external_libraries="yes"
 fi
-
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for mpfr_init in -lmpfr" >&5
 $as_echo_n "checking for mpfr_init in -lmpfr... " >&6; }
@@ -2918,16 +2912,8 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_mpfr_mpfr_init" >&5
 $as_echo "$ac_cv_lib_mpfr_mpfr_init" >&6; }
 if test "x$ac_cv_lib_mpfr_mpfr_init" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE_LIBMPFR 1
-_ACEOF
-
-  LIBS="-lmpfr $LIBS"
-
-else
-  as_fn_error $? "MPFR not found; see http://www.mpfr.org/" "$LINENO" 5
+  need_gcc_external_libraries="yes"
 fi
-
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for mpc_init2 in -lmpc" >&5
 $as_echo_n "checking for mpc_init2 in -lmpc... " >&6; }
@@ -2966,16 +2952,16 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_mpc_mpc_init2" >&5
 $as_echo "$ac_cv_lib_mpc_mpc_init2" >&6; }
 if test "x$ac_cv_lib_mpc_mpc_init2" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE_LIBMPC 1
-_ACEOF
-
-  LIBS="-lmpc $LIBS"
-
-else
-  as_fn_error $? "MPC not found; see http://www.multiprecision.org/" "$LINENO" 5
+  need_gcc_external_libraries="yes"
 fi
 
+if test x"$need_gcc_external_libraries" == xno; then :
+  NEED_GCC_EXTERNAL_LIBRARIES=true
+
+else
+  NEED_GCC_EXTERNAL_LIBRARIES=false
+
+fi
 
 # Extract the first word of "curl", so it can be a program name with args.
 set dummy curl; ac_word=$2

--- a/configure.ac
+++ b/configure.ac
@@ -18,14 +18,16 @@ AC_PATH_PROGS_FEATURE_CHECK([GSED], [gsed sed],
 	[AC_MSG_ERROR([GNU sed not found])])
 AC_SUBST([GSED], [$ac_cv_path_GSED])
 
-AC_CHECK_LIB(gmp, __gmpz_init, ,
-	[AC_MSG_ERROR([GNU MP not found; see https://gmplib.org/])])
-
-AC_CHECK_LIB(mpfr, mpfr_init, ,
-	[AC_MSG_ERROR([MPFR not found; see http://www.mpfr.org/])])
-
-AC_CHECK_LIB(mpc, mpc_init2, ,
-	[AC_MSG_ERROR([MPC not found; see http://www.multiprecision.org/])])
+need_gcc_external_libraries="no"
+AC_CHECK_LIB(gmp, __gmpz_init,
+        [need_gcc_external_libraries="yes"])
+AC_CHECK_LIB(mpfr, mpfr_init,
+        [need_gcc_external_libraries="yes"])
+AC_CHECK_LIB(mpc, mpc_init2,
+        [need_gcc_external_libraries="yes"])
+AS_IF([test x"$need_gcc_external_libraries" == xno],
+      [AC_SUBST(NEED_GCC_EXTERNAL_LIBRARIES,true)],
+      [AC_SUBST(NEED_GCC_EXTERNAL_LIBRARIES,false)])
 
 AC_PATH_PROG([CURL], [curl], [no])
 AC_PATH_PROG([WGET], [wget], [no])


### PR DESCRIPTION
GCC needs some libraries to build, and these aren't installed on some machines (RHEL, as usual).  This just calls GCC's script to download these libraries when our top-level autoconf detects the required libraries aren't installed, as opposed to just failing.