### PR TITLE
gcc: Fix the libsanitizer port, again

### DIFF
--- a/patches/gcc
+++ b/patches/gcc
@@ -273,3 +273,38 @@
    typedef unsigned int __sanitizer___kernel_old_uid_t;
    typedef unsigned int __sanitizer___kernel_old_gid_t;
  #else
+diff -ru gcc-5.1.0.orig/libsanitizer/sanitizer_common/sanitizer_platform.h gcc-5.1.0/libsanitizer/sanitizer_common/sanitizer_platform.h
+--- gcc-5.1.0.orig/libsanitizer/sanitizer_common/sanitizer_platform.h	2015-05-13 19:36:27.061421043 -0700
++++ gcc-5.1.0/libsanitizer/sanitizer_common/sanitizer_platform.h	2015-05-13 19:44:19.274355577 -0700
+@@ -98,9 +98,9 @@
+ 
+ // The AArch64 linux port uses the canonical syscall set as mandated by
+ // the upstream linux community for all new ports. Other ports may still
+-// use legacy syscalls.
++// use legacy syscalls.  The RISC-V port also does this.
+ #ifndef SANITIZER_USES_CANONICAL_LINUX_SYSCALLS
+-# if defined(__aarch64__) && SANITIZER_LINUX
++# if (defined(__aarch64__) || defined(__riscv__)) && SANITIZER_LINUX
+ # define SANITIZER_USES_CANONICAL_LINUX_SYSCALLS 1
+ # else
+ # define SANITIZER_USES_CANONICAL_LINUX_SYSCALLS 0
+diff -ru gcc-5.1.0.orig/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h gcc-5.1.0/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h
+--- gcc-5.1.0.orig/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h	2015-05-13 19:36:27.061421043 -0700
++++ gcc-5.1.0/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h	2015-05-13 19:39:13.515487834 -0700
+@@ -73,7 +73,6 @@
+   #endif
+   const unsigned struct_kernel_stat64_sz = 104;
+ #elif defined(__riscv__)
+-  const unsigned struct___old_kernel_stat_sz = 0;
+   const unsigned struct_kernel_stat_sz = 128;
+   const unsigned struct_kernel_stat64_sz = 128;
+ #elif defined(__sparc__) && defined(__arch64__)
+@@ -104,7 +103,7 @@
+ 
+ #if SANITIZER_LINUX || SANITIZER_FREEBSD
+ 
+-#if defined(__powerpc64__)
++#if defined(__powerpc64__) || defined(__riscv__)
+   const unsigned struct___old_kernel_stat_sz = 0;
+ #elif !defined(__sparc__)
+   const unsigned struct___old_kernel_stat_sz = 32;


### PR DESCRIPTION
I guess it wouldn't be a proper GCC update if it didn't break the
libsanitizer port :).  I feel like they've picked the most convoluted
set of #ifdefs possible in order to achieve this, but I just stuck
__riscv__ in some slightly different places than last time so at least
it wasn't any work to fix.

This doesn't break riscv64-unknown-linux-gnu on a5, and fixes Gentoo.