### PR TITLE
binutils: gas: fix default xlen selection

### DIFF
--- a/binutils/gas/config/tc-riscv.c
+++ b/binutils/gas/config/tc-riscv.c
@@ -56,6 +56,12 @@ struct riscv_cl_insn
   fixS *fixp;
 };
 
+/* The default architecture.  */
+#ifndef DEFAULT_ARCH
+#define DEFAULT_ARCH "riscv64"
+#endif
+static const char default_arch[] = DEFAULT_ARCH;
+
 bfd_boolean rv64 = TRUE; /* RV64 (true) or RV32 (false) */
 #define LOAD_ADDRESS_INSN (rv64 ? "ld" : "lw")
 #define ADD32_INSN (rv64 ? "addiw" : "addi")
@@ -298,6 +304,11 @@ static char *expr_end;
 const char *
 riscv_target_format (void)
 {
+  if (strcmp (default_arch, "riscv32") == 0)
+    rv64 = FALSE;
+  else if (strcmp (default_arch, "riscv64") == 0)
+    rv64 = TRUE;
+
   return rv64 ? "elf64-littleriscv" : "elf32-littleriscv";
 }
 

--- a/patches/binutils
+++ b/patches/binutils
@@ -276,13 +276,36 @@
  
  	strongarm | thumb | xscale)
  		basic_machine=arm-unknown
+--- original-binutils/gas/configure.ac
++++ binutils/gas/configure.ac
+@@ -453,7 +453,7 @@ changequote([,])dnl
+ 	AC_MSG_RESULT($enable_audio_ext)
+ 	;;
+ 
+-      i386 | s390 | sparc)
++      i386 | riscv | s390 | sparc)
+ 	if test $this_target = $target ; then
+ 	  AC_DEFINE_UNQUOTED(DEFAULT_ARCH, "${arch}", [Default architecture.])
+ 	fi
+--- original-binutils/gas/configure
++++ binutils/gas/configure
+@@ -12402,7 +12402,7 @@ $as_echo "#define NDS32_DEFAULT_AUDIO_EXT 1" >>confdefs.h
+ $as_echo "$enable_audio_ext" >&6; }
+ 	;;
+ 
+-      i386 | s390 | sparc)
++      i386 | riscv | s390 | sparc)
+ 	if test $this_target = $target ; then
+ 
+ cat >>confdefs.h <<_ACEOF
 --- original-binutils/gas/configure.tgt
 +++ binutils/gas/configure.tgt
-@@ -86,6 +86,7 @@ case ${cpu} in
+@@ -86,6 +86,8 @@ case ${cpu} in
    pj*)			cpu_type=pj endian=big ;;
    powerpc*le*)		cpu_type=ppc endian=little ;;
    powerpc*)		cpu_type=ppc endian=big ;;
-+  riscv*)		cpu_type=riscv endian=little ;;
++  riscv32*)		cpu_type=riscv endian=little arch=riscv32 ;;
++  riscv*)		cpu_type=riscv endian=little arch=riscv64 ;;
    rs6000*)		cpu_type=ppc ;;
    rl78*)		cpu_type=rl78 ;;
    rx)			cpu_type=rx ;;
@@ -290,11 +313,20 @@
    ppc-*-kaos*)				fmt=elf ;;
    ppc-*-lynxos*)			fmt=elf em=lynx ;;
  
-+  riscv*-*-*)			fmt=elf endian=little em=linux bfd_gas=yes ;;
++  riscv*-*-*)			fmt=elf endian=little em=linux ;;
 +
    s390-*-linux-*)			fmt=elf em=linux ;;
    s390-*-tpf*)				fmt=elf ;;
  
+@@ -489,7 +490,7 @@ case ${generic_target} in
+ esac
+ 
+ case ${cpu_type} in
+-  aarch64 | alpha | arm | i386 | ia64 | microblaze | mips | ns32k | or1k | or1knd | pdp11 | ppc | sparc | z80 | z8k)
++  aarch64 | alpha | arm | i386 | ia64 | microblaze | mips | ns32k | or1k | or1knd | pdp11 | ppc | riscv | sparc | z80 | z8k)
+     bfd_gas=yes
+     ;;
+ esac
 --- original-binutils/gas/Makefile.am
 +++ binutils/gas/Makefile.am
 @@ -171,6 +171,7 @@ TARGET_CPU_CFILES = \


### PR DESCRIPTION
gas currently defaults to xlen=64 all the time even when it's configured
for a riscv32-elf target.  Fix this by leveraging the existing default
arch logic like x86/s390 targets do.

The meaning of "arch" is a bit confusing in this case as we're using it
only for the xlen and not for the various extensions.  But since this is
really the only thing we pull from the tuple, and it's the naming that
the common gas code uses, oh well.