### PR TITLE
Fix some glibc FP routines for non-F

### DIFF
--- a/glibc/sysdeps/riscv/fpu/s_fdim.c
+++ b/glibc/sysdeps/riscv/fpu/s_fdim.c
@@ -9,8 +9,13 @@ double __fdim (double x, double y)
   if (x <= y)
     return 0.0;
 
+#ifdef __riscv_soft_float
+  if (isinf(diff))
+    errno = ERANGE;
+#else
   if (__builtin_expect(_FCLASS(diff) & _FCLASS_INF, 0))
     errno = ERANGE;
+#endif
 
   return diff;
 }

--- a/glibc/sysdeps/riscv/fpu/s_fdimf.c
+++ b/glibc/sysdeps/riscv/fpu/s_fdimf.c
@@ -9,8 +9,13 @@ float __fdimf (float x, float y)
   if (x <= y)
     return 0.0f;
 
+#ifdef __riscv_soft_float
+  if (isinf(diff))
+    errno = ERANGE;
+#else
   if (__builtin_expect(_FCLASS(diff) & _FCLASS_INF, 0))
     errno = ERANGE;
+#endif
 
   return diff;
 }

--- a/glibc/sysdeps/riscv/fpu/s_fmax.c
+++ b/glibc/sysdeps/riscv/fpu/s_fmax.c
@@ -2,8 +2,16 @@
 
 double __fmax (double x, double y)
 {
+#ifdef __riscv_soft_float
+  if (isnan(x))
+    return y;
+  if (isnan(y))
+    return x;
+  return (x > y) ? x : y;
+#else
   double res;
   asm ("fmax.d %0, %1, %2" : "=f"(res) : "f"(x), "f"(y));
   return res;
+#endif
 }
 weak_alias (__fmax, fmax)

--- a/glibc/sysdeps/riscv/fpu/s_fmaxf.c
+++ b/glibc/sysdeps/riscv/fpu/s_fmaxf.c
@@ -2,8 +2,16 @@
 
 float __fmaxf (float x, float y)
 {
+#ifdef __riscv_soft_float
+  if (isnan(x))
+    return y;
+  if (isnan(y))
+    return x;
+  return (x > y) ? x : y;
+#else
   float res;
   asm ("fmax.s %0, %1, %2" : "=f"(res) : "f"(x), "f"(y));
   return res;
+#endif
 }
 weak_alias (__fmaxf, fmaxf)

--- a/glibc/sysdeps/riscv/fpu/s_fmin.c
+++ b/glibc/sysdeps/riscv/fpu/s_fmin.c
@@ -2,8 +2,16 @@
 
 double __fmin (double x, double y)
 {
+#ifdef __riscv_soft_float
+  if (isnan(x))
+      return y;
+  if (isnan(y))
+      return x;
+  return (x < y) ? x : y;
+#else
   double res;
   asm ("fmin.d %0, %1, %2" : "=f"(res) : "f"(x), "f"(y));
   return res;
+#endif
 }
 weak_alias (__fmin, fmin)

--- a/glibc/sysdeps/riscv/fpu/s_fminf.c
+++ b/glibc/sysdeps/riscv/fpu/s_fminf.c
@@ -2,8 +2,16 @@
 
 float __fminf (float x, float y)
 {
+#ifdef __riscv_soft_float
+  if (isnan(x))
+    return y;
+  if (isnan(y))
+    return x;
+  return (x < y) ? x : y;
+#else
   float res;
   asm ("fmin.s %0, %1, %2" : "=f"(res) : "f"(x), "f"(y));
   return res;
+#endif
 }
 weak_alias (__fminf, fminf)

--- a/glibc/sysdeps/riscv/fpu_control.h
+++ b/glibc/sysdeps/riscv/fpu_control.h
@@ -30,10 +30,14 @@
 #define _FPU_DEFAULT  0x00000000
 typedef unsigned int fpu_control_t;
 #define _FPU_GETCW(cw) (cw) = 0
+#define _FPU_GETROUND(cw) (cw) = 0
+#define _FPU_GETFLAGS(cw) (cw) = 0
 #define _FPU_SETCW(cw) do { } while (0)
+#define _FPU_SETROUND(cw) do { } while (0)
+#define _FPU_SETFLAGS(cw) do { } while (0)
 extern fpu_control_t __fpu_control;
 
-#else /* __mips_soft_float */
+#else /* __riscv_soft_float */
 
 /* rounding control */
 #define _FPU_RC_NEAREST 0x0
@@ -87,6 +91,6 @@ extern fpu_control_t __fpu_control;
 #define _FCLASS_INF      (_FCLASS_MINF | _FCLASS_PINF)
 #define _FCLASS_NAN      (_FCLASS_SNAN | _FCLASS_QNAN)
 
-#endif /* __mips_soft_float */
+#endif /* __riscv_soft_float */
 
 #endif	/* fpu_control.h */


### PR DESCRIPTION
Some glibc floating point routines use inline assembly.  This changes
them to use regular C code to do this when compiled without hardware
floatint-point support.  The change just uses regular C to perform
these operations when compiled on ABIs without hardware floating
point.