### PR TITLE
Make GCC pass through non-standard ISA strings

### DIFF
--- a/gcc/gcc/common/config/riscv/riscv-common.c
+++ b/gcc/gcc/common/config/riscv/riscv-common.c
@@ -76,6 +76,12 @@ riscv_parse_arch_string (const char *isa, int *flags)
   if (*p == 'C')
     *flags |= MASK_RVC, p++;
 
+  /* FIXME: For now we just stop parsing when faced with a
+     non-standard RISC-V ISA extension, partially becauses of a
+     problem with the naming scheme. */
+  if (*p == 'X')
+    return;
+
   if (*p)
     {
       error ("-march=%s: unsupported ISA substring %s", isa, p);


### PR DESCRIPTION
This simply stops GCC's parse whenever it sees an 'X' in an ISA
string.  This is the best I can do until some clarafications are made
to the RISC-V user spec that allows ISA extensions to be parsed.