### PR TITLE
Don't pass "--with-arch" by default

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -16,7 +16,7 @@ glibc_url := $(GNU_MIRROR)/glibc/glibc-$(glibc_version).tar.gz
 newlib_url := ftp://sourceware.org/pub/newlib/newlib-$(newlib_version).tar.gz
 
 XLEN ?= @XLEN@
-ARCH ?= @ARCH@
+WITH_ARCH ?= @WITH_ARCH@
 SYSROOT := $(INSTALL_DIR)/sysroot
 
 SHELL := /bin/sh
@@ -161,7 +161,7 @@ stamps/build-gcc-linux-stage1: src/gcc stamps/build-binutils-linux \
 		--disable-nls \
 		$(MULTILIB_FLAGS) \
 		--disable-bootstrap \
-		--with-arch=$(ARCH)
+		$(WITH_ARCH)
 	$(MAKE) -C $(notdir $@) inhibit-libc=true all-gcc
 	$(MAKE) -C $(notdir $@) inhibit-libc=true install-gcc
 	$(MAKE) -C $(notdir $@) inhibit-libc=true all-target-libgcc
@@ -185,7 +185,7 @@ stamps/build-gcc-linux-stage2: src/gcc stamps/build-glibc-linux$(XLEN) \
 		--disable-nls \
 		$(MULTILIB_FLAGS) \
 		--disable-bootstrap \
-		--with-arch=$(ARCH)
+		$(WITH_ARCH)
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
@@ -226,7 +226,7 @@ stamps/build-gcc-newlib: src/newlib-gcc stamps/build-binutils-newlib
 		--disable-libquadmath \
 		--disable-libgomp \
 		--disable-nls \
-		--with-arch=$(ARCH)
+		$(WITH_ARCH)
 	$(MAKE) -C $(notdir $@) inhibit-libc=true
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@

--- a/configure
+++ b/configure
@@ -589,7 +589,7 @@ glibc_configure_flags
 float_asflags
 float_cflags
 atomic_cflags
-ARCH
+WITH_ARCH
 XLEN
 default_target
 FETCHER
@@ -3153,11 +3153,7 @@ fi
 
 # Check whether --with-arch was given.
 if test "${with_arch+set}" = set; then :
-  withval=$with_arch; ARCH=$withval
-
-else
-  ARCH=IMAFD
-
+  withval=$with_arch; WITH_ARCH=--with-arch=$withval
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -59,8 +59,8 @@ AC_ARG_WITH(xlen,
 AC_ARG_WITH(arch,
 	[AS_HELP_STRING([--with-arch=IMAFD],
 		[Sets the base RISC-V ISA, defaults to IMAFD])],
-	AC_SUBST(ARCH, $withval),
-	AC_SUBST(ARCH, IMAFD)
+	AC_SUBST(WITH_ARCH, --with-arch=$withval),
+	AC_SUBST(WITH_ARCH,)
 	)
 
 AC_ARG_ENABLE(atomic,


### PR DESCRIPTION
I commited this too quickly last time and it's been breaking a whole
bunch of stuff.  Until I managed to get multilib working in a sane
way, I'm just going to go ahead and turn it off by default.  You can
still pass "--with-arch", but doing so while also passing things like
"--enable-multilib" or "--disable-atomics" might have unexpected
results.