### PR TITLE
upgrade newlib to 2.2.0

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -6,7 +6,7 @@ PACKAGES := binutils gcc glibc newlib
 gcc_version := 5.2.0
 binutils_version := 2.25
 glibc_version := 2.22
-newlib_version := 1.18.0
+newlib_version := 2.2.0
 
 DISTDIR ?= /var/cache/distfiles
 GNU_MIRROR := http://mirrors.kernel.org/gnu

--- a/newlib/newlib/libc/machine/riscv/machine/_types.h
+++ b/newlib/newlib/libc/machine/riscv/machine/_types.h
@@ -27,7 +27,7 @@ typedef unsigned long long __ino_t;
 #define __nlink_t_defined
 typedef unsigned int __nlink_t;
 
-#define __mode_t_defined
-typedef unsigned int __mode_t;
+#define __ssize_t_defined
+typedef long signed int _ssize_t;
 
 #endif

--- a/patches/gcc
+++ b/patches/gcc
@@ -308,3 +308,28 @@ diff -ru gcc-5.1.0.orig/libsanitizer/sanitizer_common/sanitizer_platform_limits_
    const unsigned struct___old_kernel_stat_sz = 0;
  #elif !defined(__sparc__)
    const unsigned struct___old_kernel_stat_sz = 32;
+--- original-gcc/libstdc++-v3/configure
++++ gcc/libstdc++-v3/configure
+@@ -16641,7 +16641,7 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+   # Long term, -std=c++0x could be even better, could manage to explicitly
+   # request C99 facilities to the underlying C headers.
+   ac_save_CXXFLAGS="$CXXFLAGS"
+-  CXXFLAGS="$CXXFLAGS -std=c++98"
++  CXXFLAGS="$CXXFLAGS -std=gnu++98"
+   ac_save_LIBS="$LIBS"
+   ac_save_gcc_no_link="$gcc_no_link"
+ 
+@@ -17263,9 +17263,11 @@ rm -f core conftest.err conftest.$ac_obj
+ $as_echo "$glibcxx_cv_c99_wchar" >&6; }
+   fi
+ 
++  # For newlib, don't check complex since missing c99 functions, but
++  #   rest of c99 stuff is there so don't loose it
+   # Option parsed, now set things appropriately.
+   if test x"$glibcxx_cv_c99_math" = x"no" ||
+-     test x"$glibcxx_cv_c99_complex" = x"no" ||
++     # test x"$glibcxx_cv_c99_complex" = x"no" ||
+      test x"$glibcxx_cv_c99_stdio" = x"no" ||
+      test x"$glibcxx_cv_c99_stdlib" = x"no" ||
+      test x"$glibcxx_cv_c99_wchar" = x"no"; then
+

--- a/patches/newlib
+++ b/patches/newlib
@@ -1,6 +1,6 @@
 --- original-newlib/libgloss/configure
 +++ newlib/libgloss/configure
-@@ -710,6 +710,7 @@ i960
+@@ -678,6 +678,7 @@ sparc_leon
  sparc
  wince
  mips
@@ -8,7 +8,7 @@
  rs6000
  mn10200
  mn10300
-@@ -2470,6 +2471,10 @@ case "${target}" in
+@@ -2449,6 +2450,10 @@ case "${target}" in
  	subdirs="$subdirs mips"
  
  	;;
@@ -21,7 +21,7 @@
  
 --- original-newlib/libgloss/configure.in
 +++ newlib/libgloss/configure.in
-@@ -61,6 +61,9 @@ case "${target}" in
+@@ -75,6 +75,9 @@ case "${target}" in
    mips*-*-*)
  	AC_CONFIG_SUBDIRS([mips])
  	;;
@@ -33,7 +33,7 @@
  	;;
 --- original-newlib/newlib/configure.host
 +++ newlib/newlib/configure.host
-@@ -198,6 +198,10 @@ case "${host_cpu}" in
+@@ -210,6 +210,10 @@ case "${host_cpu}" in
    mep)
  	machine_dir=mep
  	;;
@@ -46,7 +46,7 @@
  	;;
 --- original-newlib/newlib/libc/include/machine/ieeefp.h
 +++ newlib/newlib/libc/include/machine/ieeefp.h
-@@ -152,6 +152,14 @@
+@@ -170,6 +170,14 @@
  #define __IEEE_LITTLE_ENDIAN
  #endif
  
@@ -63,7 +63,7 @@
  #endif
 --- original-newlib/newlib/libc/include/machine/setjmp.h
 +++ newlib/newlib/libc/include/machine/setjmp.h
-@@ -258,6 +258,11 @@ _BEGIN_STD_C
+@@ -338,6 +338,11 @@ _BEGIN_STD_C
  #define _JBLEN 0x44
  #endif
  
@@ -75,38 +75,22 @@
  #ifdef _JBLEN
  #ifdef _JBTYPE
  typedef	_JBTYPE jmp_buf[_JBLEN];
---- original-newlib/newlib/libc/include/sys/stat.h
-+++ newlib/newlib/libc/include/sys/stat.h
-@@ -31,8 +31,23 @@ struct	stat
-   uid_t		st_uid;
-   gid_t		st_gid;
-   dev_t		st_rdev;
-+#if defined(__riscv__)
-+  dev_t		__pad1;
-+#endif
-   off_t		st_size;
--#if defined(__rtems__)
-+#if defined(__riscv__)
-+  unsigned int	st_blksize;
-+  unsigned int	__pad2;
-+  unsigned long long	st_blocks;
-+  time_t	st_atime;
-+  time_t	__pad3;
-+  time_t	st_mtime;
-+  time_t	__pad4;
-+  time_t	st_ctime;
-+  time_t	__pad5;
-+  unsigned int	__unused4;
-+  unsigned int	__unused5;
-+#elif defined(__rtems__)
-   struct timespec st_atim;
-   struct timespec st_mtim;
-   struct timespec st_ctim;
+--- original-newlib/newlib/libc/include/sys/config.h
++++ newlib/newlib/libc/include/sys/config.h
+@@ -75,7 +75,7 @@
+ #define _POINTER_INT short
+ #endif
+ 
+-#if defined(__m68k__) || defined(__mc68000__)
++#if defined(__m68k__) || defined(__mc68000__) || defined(__riscv__)
+ #define _READ_WRITE_RETURN_TYPE _ssize_t
+ #endif
+ 
 --- original-newlib/newlib/libc/include/sys/types.h
 +++ newlib/newlib/libc/include/sys/types.h
-@@ -125,6 +125,9 @@ struct itimerspec {
- typedef	long	daddr_t;
- typedef	char *	caddr_t;
+@@ -147,6 +147,9 @@ typedef	char *	caddr_t;
+ #define __caddr_t_defined
+ #endif
  
 +#ifdef __ino_t_defined
 +typedef __ino_t ino_t;
@@ -114,7 +98,7 @@
  #ifndef __CYGWIN__
  #if defined(__MS_types__) || defined(__rtems__) || \
      defined(__sparc__) || defined(__SPU__)
-@@ -133,6 +136,7 @@ typedef	unsigned long	ino_t;
+@@ -155,6 +158,7 @@ typedef	unsigned long	ino_t;
  typedef	unsigned short	ino_t;
  #endif
  #endif /*__CYGWIN__*/
@@ -122,17 +106,17 @@
  
  #ifdef __MS_types__
  typedef unsigned long vm_offset_t;
-@@ -176,6 +180,9 @@ typedef	long key_t;
+@@ -197,6 +201,9 @@ typedef int pid_t;
+ typedef _mode_t mode_t;
  #endif
- typedef _ssize_t ssize_t;
  
 +#ifdef __mode_t_defined
 +typedef __mode_t mode_t;
 +#else
  #ifndef __CYGWIN__
- #ifdef __MS_types__
- typedef	char *	addr_t;
-@@ -192,8 +199,13 @@ typedef unsigned int mode_t _ST_INT32;
+ typedef	long key_t;
+ #endif
+@@ -218,8 +225,13 @@ typedef unsigned int mode_t _ST_INT32;
  #endif
  #endif /* ! __MS_types__ */
  #endif /*__CYGWIN__*/
@@ -146,29 +130,9 @@
  
  /* We don't define fd_set and friends if we are compiling POSIX
     source, or if we have included (or may include as indicated
---- original-newlib/newlib/libc/libc.texinfo
-+++ newlib/newlib/libc/libc.texinfo
-@@ -426,7 +426,7 @@ usage as the ANSI C version from @file{s
- @printindex cp
- 
- @tex
--% I think something like @colophon should be in texinfo.  In the
-+% I think something like @@colophon should be in texinfo.  In the
- % meantime:
- \long\def\colophon{\hbox to0pt{}\vfill
- \centerline{The body of this manual is set in}
-@@ -437,7 +437,7 @@ usage as the ANSI C version from @file{s
- \centerline{{\sl\fontname\tensl\/}}
- \centerline{are used for emphasis.}\vfill}
- \page\colophon
--% Blame: pesch@cygnus.com, 28mar91.
-+% Blame: pesch@@cygnus.com, 28mar91.
- @end tex
- 
- @contents
 --- original-newlib/newlib/libc/machine/configure
 +++ newlib/newlib/libc/machine/configure
-@@ -981,6 +981,7 @@ m88k
+@@ -811,6 +811,7 @@ m88k
  mep
  microblaze
  mips
@@ -176,7 +140,7 @@
  mn10200
  mn10300
  moxie
-@@ -12665,6 +12666,8 @@ subdirs="$subdirs a29k"
+@@ -11882,6 +11883,8 @@ subdirs="$subdirs a29k"
   ;;
  	mips) subdirs="$subdirs mips"
   ;;
@@ -187,7 +151,7 @@
  	mn10300) subdirs="$subdirs mn10300"
 --- original-newlib/newlib/libc/machine/configure.in
 +++ newlib/newlib/libc/machine/configure.in
-@@ -46,6 +46,7 @@ if test -n "${machine_dir}"; then
+@@ -50,6 +50,7 @@ if test -n "${machine_dir}"; then
  	mep ) AC_CONFIG_SUBDIRS(mep) ;;
  	microblaze ) AC_CONFIG_SUBDIRS(microblaze) ;;
  	mips) AC_CONFIG_SUBDIRS(mips) ;;
@@ -195,23 +159,3 @@
  	mn10200) AC_CONFIG_SUBDIRS(mn10200) ;;
  	mn10300) AC_CONFIG_SUBDIRS(mn10300) ;;
  	moxie) AC_CONFIG_SUBDIRS(moxie) ;;
---- original-newlib/newlib/libm/libm.texinfo
-+++ newlib/newlib/libm/libm.texinfo
-@@ -134,7 +134,7 @@ For such platforms, the long double math
- @printindex cp
- 
- @tex
--% I think something like @colophon should be in texinfo.  In the
-+% I think something like @@colophon should be in texinfo.  In the
- % meantime:
- \long\def\colophon{\hbox to0pt{}\vfill
- \centerline{The body of this manual is set in}
-@@ -145,7 +145,7 @@ For such platforms, the long double math
- \centerline{{\sl\fontname\tensl\/}}
- \centerline{are used for emphasis.}\vfill}
- \page\colophon
--% Blame: pesch@cygnus.com, 28mar91.
-+% Blame: pesch@@cygnus.com, 28mar91.
- @end tex
- 
- @contents


### PR DESCRIPTION
All in all, the changes to build newlib 2.2.0 are pretty minor. Being able to use the included stat.h rather than modifying it should also be a useful simplification.