### PR TITLE
binutils: Fix comment.

### DIFF
--- a/patches/binutils
+++ b/patches/binutils
@@ -416,7 +416,7 @@
  #define EM_INTEL207	207	/* Reserved by Intel */
  #define EM_INTEL208	208	/* Reserved by Intel */
  #define EM_INTEL209	209	/* Reserved by Intel */
-+#define EM_RISCV	243	/* Reserved by Intel */
++#define EM_RISCV	243	/* RISC-V */
  
  /* If it is necessary to assign new unofficial EM_* values, please pick large
     random numbers (0x8523, 0xa7f2, etc.) to minimize the chances of collision


### PR DESCRIPTION
ELF machine type 243 is officially reserved by RISC-V, not Intel