### PR TITLE
Update glibc to 2.22

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -5,7 +5,7 @@ INSTALL_DIR := @prefix@
 PACKAGES := binutils gcc glibc newlib
 gcc_version := 5.2.0
 binutils_version := 2.25
-glibc_version := 2.21
+glibc_version := 2.22
 newlib_version := 1.18.0
 
 DISTDIR ?= /var/cache/distfiles

--- a/glibc/sysdeps/riscv/strcmp.S
+++ b/glibc/sysdeps/riscv/strcmp.S
@@ -3,7 +3,7 @@
 #include <sysdep.h>
 #include <sys/asm.h>
 
-#if BYTE_ORDER != LITTLE_ENDIAN
+#if __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
 # error
 #endif
 

--- a/glibc/sysdeps/riscv/sys/asm.h
+++ b/glibc/sysdeps/riscv/sys/asm.h
@@ -56,6 +56,7 @@ symbol:						\
 /*
  * END - mark end of function
  */
+#undef END
 #define END(function)				\
 		cfi_endproc;			\
 		.size	function,.-function

--- a/glibc/sysdeps/unix/sysv/linux/riscv/sysdep.h
+++ b/glibc/sysdeps/unix/sysv/linux/riscv/sysdep.h
@@ -27,6 +27,7 @@
 
 #define ENTRY(name) LEAF(name)
 
+#undef PSEUDO_END
 #define PSEUDO_END(sym) END(sym)
 
 #define PSEUDO_NOERRNO(name, syscall_name, args)	\

--- a/glibc/sysdeps/unix/sysv/linux/riscv/sysdep.h
+++ b/glibc/sysdeps/unix/sysv/linux/riscv/sysdep.h
@@ -21,6 +21,11 @@
 #include <sysdeps/unix/sysv/linux/generic/sysdep.h>
 #include <tls.h>
 
+/* In order to get __set_errno() definition in INLINE_SYSCALL.  */
+#ifndef __ASSEMBLER__
+#include <errno.h>
+#endif
+
 #ifdef __ASSEMBLER__
 
 #include <sys/asm.h>
@@ -70,16 +75,14 @@ L(syse1):
 /* Define a macro which expands into the inline wrapper code for a system
    call.  */
 #undef INLINE_SYSCALL
-#define INLINE_SYSCALL(name, nr, args...)				\
-  ({ INTERNAL_SYSCALL_DECL(err);					\
-     long result_var = INTERNAL_SYSCALL (name, err, nr, args);		\
-     if (result_var < 0)						\
-       {								\
-	 /* __syscall_error handles result_var <= -4096 corner case */	\
-	 extern long __syscall_error (long) attribute_hidden;		\
-	 result_var = __syscall_error (result_var);			\
-       }								\
-     result_var; })
+# define INLINE_SYSCALL(name, nr, args...)                              \
+    ({ unsigned long _sys_result = INTERNAL_SYSCALL (name, , nr, args); \
+        if (__builtin_expect (INTERNAL_SYSCALL_ERROR_P (_sys_result, ), 0)) \
+        {                                                               \
+            __set_errno (INTERNAL_SYSCALL_ERRNO (_sys_result, ));       \
+            _sys_result = (unsigned long) -1;                           \
+        }                                                               \
+        (long) _sys_result; })
 
 #define INTERNAL_SYSCALL_DECL(err) do { } while (0)
 


### PR DESCRIPTION
This was released this morning.  I've tried to split up the patches such that everything compiles until the version bump, but I didn't bother verifying this.  I think the only one that could be wrong is the INLINE_SYSCALL change, but it looks like all the relevant macros do the same thing as __syscall_error so I think it should be safe.