### PR TITLE
Check for CC and CXX at configure-time

### DIFF
--- a/configure
+++ b/configure
@@ -1814,6 +1814,13 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
+if test x"$CC" != x; then :
+  as_fn_error $? "CC is set, which will cause the host tools to build riscv-glibc" "$LINENO" 5
+fi
+if test x"$CXX" != x; then :
+  as_fn_error $? "CXX is set, which will cause the host tools to build riscv-glibc" "$LINENO" 5
+fi
+
 ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,10 @@
 AC_INIT(riscv-toolchain, 1.0)
 
+AS_IF([test x"$CC" != x],
+      [AC_MSG_ERROR([CC is set, which will cause the host tools to build riscv-glibc])])
+AS_IF([test x"$CXX" != x],
+      [AC_MSG_ERROR([CXX is set, which will cause the host tools to build riscv-glibc])])
+
 AC_PROG_CC
 AC_PROG_FGREP
 


### PR DESCRIPTION
Bug #81 resulted in a failure that was far from the actual problem
because CC was being set to "gcc-4.8" in order to try and use a new
host toolchain, which resulted in riscv-glibc being built with the
host toolchain.  In order to make these issues more apparent, this
simply errors out when CC or CXX is set.