### PR TITLE
Use "cp -a" instead of "cp -R"

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -71,7 +71,7 @@ $(addprefix src/original-,$(PACKAGES)):
 
 $(addprefix src/,$(PACKAGES)): src/%: src/original-%
 	rm -rf $@ $@.tmp
-	cp -R $< $@.tmp
+	cp -a $< $@.tmp
 	$(srcdir)/scripts/cp_s $(srcdir)/$(notdir $@) $@.tmp
 	cd $@.tmp && patch -p1 < $(srcdir)/patches/$(notdir $@)
 	if test -f $@.tmp/contrib/download_prerequisites && test "@NEED_GCC_EXTERNAL_LIBRARIES@" == "true"; then cd $@.tmp && ./contrib/download_prerequisites; fi
@@ -100,7 +100,7 @@ stamps/build-binutils-linux: src/binutils
 
 stamps/build-linux-headers:
 	mkdir -p $(SYSROOT)/usr/
-	cp -R $(srcdir)/linux-headers/include $(SYSROOT)/usr/
+	cp -a $(srcdir)/linux-headers/include $(SYSROOT)/usr/
 	mkdir -p $(dir $@) && touch $@
 
 stamps/build-glibc-linux-headers: src/glibc stamps/build-gcc-linux-stage1
@@ -204,9 +204,9 @@ stamps/build-binutils-newlib: src/binutils
 
 src/newlib-gcc: src/gcc src/newlib
 	rm -rf $@ $@.tmp
-	cp -R src/gcc $@.tmp
-	cp -R src/newlib/newlib $@.tmp
-	cp -R src/newlib/libgloss $@.tmp
+	cp -a src/gcc $@.tmp
+	cp -a src/newlib/newlib $@.tmp
+	cp -a src/newlib/libgloss $@.tmp
 	$(srcdir)/scripts/cp_s $(srcdir)/newlib $@.tmp
 	mv $@.tmp $@
 


### PR DESCRIPTION
"cp -a" preserves everything about the copied files, the most
important of which for us is the modification times.  It appears all
the GNU stuff has sufficiently broken toolchains such that randomizing
the order of the modification times of the distributed sources is
sufficient to break the build.  I'm hoping this fixes an intermittent
failure in my builds.