### PR TITLE
Fix multilib build.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -53,14 +53,14 @@ ifneq ($(findstring --disable-multilib,$(MULTILIB_FLAGS)),)
 linux: stamps/build-gcc-linux-stage2
 else
 linux:
-	$(MAKE) stamps/build-gcc-linux-stage1 XLEN=
-	$(MAKE) stamps/build-glibc-linux XLEN=
+	$(MAKE) stamps/build-gcc-linux-stage1 XLEN=64
+	$(MAKE) stamps/build-glibc-linux64 XLEN=64
 	$(MAKE) stamps/build-glibc-linux32 XLEN=32 \
-		CC="riscv-unknown-linux-gnu-gcc -m32" \
-		READELF=riscv-unknown-linux-gnu-readelf \
+		CC="riscv64-unknown-linux-gnu-gcc -m32" \
+		READELF=riscv64-unknown-linux-gnu-readelf \
 		CFLAGS_FOR_TARGET_EXTRA="-m32" \
 		ASFLAGS_FOR_TARGET_EXTRA="-m32"
-	$(MAKE) stamps/build-gcc-linux-stage2 XLEN=
+	$(MAKE) stamps/build-gcc-linux-stage2 XLEN=64
 endif
 
 $(addprefix src/original-,$(PACKAGES)):


### PR DESCRIPTION
Since riscv- is no longer valid as a synosym for riscv64-, adjust
the multilib build accordingly.