### PR TITLE
Split config.bfd to use riscv{32,64}, not riscv*

### DIFF
--- a/patches/binutils
+++ b/patches/binutils
@@ -82,12 +82,17 @@
  rs6000)		 targ_archs="bfd_rs6000_arch bfd_powerpc_arch" ;;
  s390*)		 targ_archs=bfd_s390_arch ;;
  sh*)		 targ_archs=bfd_sh_arch ;;
-@@ -1319,6 +1320,14 @@ case "${targ}" in
+@@ -1319,6 +1320,19 @@ case "${targ}" in
      targ_defvec=rl78_elf32_vec
      ;;
  
++  riscv32-*-*)
++    targ_defvec=riscv_elf32_vec
++    targ_selvecs="riscv_elf32_vec"
++    ;;
++
 +#ifdef BFD64
-+  riscv*-*-*)
++  riscv64-*-*)
 +    targ_defvec=riscv_elf64_vec
 +    targ_selvecs="riscv_elf32_vec riscv_elf64_vec"
 +    want64=true


### PR DESCRIPTION
I'm trying to rebase our binutils port off of upstream's git repo, and
this is one of the things I ended up noticing.  I believe this is the
correct thing to do, since we're now only supporting riscv32/riscv64
as our tuples.