### PR TITLE
Handle lower-case ISA strings

### DIFF
--- a/binutils/gas/config/tc-riscv.c
+++ b/binutils/gas/config/tc-riscv.c
@@ -112,7 +112,7 @@ riscv_subset_supports (const char *feature)
     return FALSE;
 
   for (s = riscv_subsets; s != NULL; s = s->next)
-    if (strcmp (s->name, p) == 0)
+    if (strcasecmp (s->name, p) == 0)
       /* FIXME: once we support version numbers:
 	 return major == s->version_major && minor <= s->version_minor; */
       return TRUE;


### PR DESCRIPTION
We'd changed the ISA string parser to be case-insensitive, but when doing that
it made all "X*" extensions upper case.  The result was that the instruction
table matcher would skip "Xcustom" extensions, since they showed up as
"XCUSTOM".

This patch changes the ISA subset matching function to be case insensitive, to
match the parser.