### PR TITLE
gcc: re-organize multilib hierarchy for newlib gcc.

### DIFF
--- a/gcc/gcc/config/riscv/t-elf
+++ b/gcc/gcc/config/riscv/t-elf
@@ -1,4 +1,4 @@
 # Build the libraries for both hard and soft floating point
 
-MULTILIB_OPTIONS = msoft-float m64/m32 mno-atomic
-MULTILIB_DIRNAMES = soft-float 64 32 no-atomic
+MULTILIB_OPTIONS = m64/m32 msoft-float mno-atomic
+MULTILIB_DIRNAMES = 64 32 soft-float no-atomic


### PR DESCRIPTION
Fix 1st-level hierarchy to 64/32 not soft-float. It is same with glibc gcc, also.