### PR TITLE
Bump binutils to 2.25.1

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -4,7 +4,7 @@ INSTALL_DIR := @prefix@
 
 PACKAGES := binutils gcc glibc newlib
 gcc_version := 5.2.0
-binutils_version := 2.25
+binutils_version := 2.25.1
 glibc_version := 2.22
 newlib_version := 2.2.0
 

--- a/binutils/bfd/elfnn-riscv.c
+++ b/binutils/bfd/elfnn-riscv.c
@@ -973,9 +973,9 @@ riscv_elf_adjust_dynamic_symbol (struct bfd_link_info *info,
     }
 
   if (eh->tls_type & ~GOT_NORMAL)
-    return _bfd_elf_adjust_dynamic_copy (h, htab->sdyntdata);
+    return _bfd_elf_adjust_dynamic_copy (info, h, htab->sdyntdata);
 
-  return _bfd_elf_adjust_dynamic_copy (h, htab->sdynbss);
+  return _bfd_elf_adjust_dynamic_copy (info, h, htab->sdynbss);
 }
 
 /* Allocate space in .plt, .got and associated reloc sections for


### PR DESCRIPTION
This just requires a single extra argument to a function call, which I copied
from aarch64.  I've only tested that newlib builds, but I don't see how this
could cause any problems... :)

I was hoping this would help with my attempts to integrate the GDB and binutils
ports into one repo for upstreaming, but it looks like 2.25.1 is still a bit
too old for this.