### PR TITLE
Correct the "{l,s}{b,h,w,d} REG, ADDR, REG" format

### DIFF
--- a/binutils/gas/config/tc-riscv.c
+++ b/binutils/gas/config/tc-riscv.c
@@ -1607,6 +1607,9 @@ rvc_lui:
 	    case 'A':
 	      my_getExpression (imm_expr, s);
 	      normalize_constant_expr (imm_expr);
+	      /* The 'A' format specifier must be a symbol. */
+	      if (imm_expr->X_op != O_symbol)
+	        break;
 	      *imm_reloc = BFD_RELOC_32;
 	      s = expr_end;
 	      continue;


### PR DESCRIPTION
ADDR in this format is only meant to be a symbolic address, not a numeric
address.  Things are this way because of linker relaxation.  Passing a numeric
address would result in an internal assertion triggering, this patch just makes
gas reject these instructions cleanly.

This compiles glibc on a5 for me.  This should fix bug #106.