### PR TITLE
Actually support MEMMODEL_SYNC_*

### DIFF
--- a/gcc/gcc/config/riscv/riscv.c
+++ b/gcc/gcc/config/riscv/riscv.c
@@ -2825,15 +2825,20 @@ riscv_memory_model_suffix (enum memmodel model)
     {
       case MEMMODEL_ACQ_REL:
       case MEMMODEL_SEQ_CST:
+      case MEMMODEL_SYNC_SEQ_CST:
 	return ".sc";
       case MEMMODEL_ACQUIRE:
       case MEMMODEL_CONSUME:
+      case MEMMODEL_SYNC_ACQUIRE:
 	return ".aq";
       case MEMMODEL_RELEASE:
+      case MEMMODEL_SYNC_RELEASE:
 	return ".rl";
       case MEMMODEL_RELAXED:
 	return "";
-      default: gcc_unreachable();
+      default:
+        fprintf(stderr, "riscv_memory_model_suffix(%ld)\n", model);
+        gcc_unreachable();
     }
 }
 


### PR DESCRIPTION
I didn't properly check for changes required to support MEMMODEL_SYNC_*, this
looks like the last one I need to make (based on git grep).  The rationale is
the same as the previous one.