### PR TITLE
unset CC and CXX before glibc build

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -138,7 +138,7 @@ stamps/build-glibc-linux-headers: src/glibc stamps/build-gcc-linux-stage1
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	mkdir -p $(SYSROOT)/usr/lib $(SYSROOT)/lib
-	cd $(notdir $@) && $(CURDIR)/$</configure \
+	cd $(notdir $@) && CC= CXX= $(CURDIR)/$</configure \
 		--host=riscv$(XLEN)-unknown-linux-gnu \
 		--prefix=/usr \
 		libc_cv_forced_unwind=yes \
@@ -154,7 +154,7 @@ stamps/build-glibc-linux$(XLEN)$(MULTILIB): src/glibc stamps/build-gcc-linux-sta
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	mkdir -p $(SYSROOT)/usr/lib $(SYSROOT)/lib
-	cd $(notdir $@) && CFLAGS="$(CFLAGS_FOR_TARGET) -g -O2" \
+	cd $(notdir $@) && CC= CXX= CFLAGS="$(CFLAGS_FOR_TARGET) -g -O2" \
 		ASFLAGS="$(ASFLAGS_FOR_TARGET)" \
 		$(CURDIR)/$</configure \
 		--host=riscv$(XLEN)-unknown-linux-gnu \


### PR DESCRIPTION
If the user set them for earlier stages we don't want to use those.

On travis we need to set CC and CXX to get the right version of gcc, this fixes that build.