### PR TITLE
Enable reent syscall layer for standalnone baremetal environment (wit…

### DIFF
--- a/patches/newlib
+++ b/patches/newlib
@@ -39,7 +39,7 @@
  	;;
 +  riscv*)
 +	machine_dir=riscv
-+	newlib_cflags="${newlib_cflags} -DREENTRANT_SYSCALLS_PROVIDED"
++	newlib_cflags="${newlib_cflags}"
 +	;;
    mips*)
  	machine_dir=mips


### PR DESCRIPTION
…hout pk).

- with -DREENTRANT_SYSCALLS_PROVIDED (before this commit)
	There is no point that application could provide reent syscall
	implementation.

	  (libc.a)    (application/non-reent)
	fxxx(reent) ---> xxx()                       ; standalone

- without -DREENTRANT_SYSCALLS_PROVIDED (this commit)
	There is a point that application could provide reent syscall
	implementation.

	  (libc.a)         (libg.a)     (libgloss.a)
	fxxx(reent) ---> _xxx_r(reent) ---> xxx()    ; pk based

	  (libc.a)       (application/reent)
	fxxx(reent) ---> _xxx_r(reent)               ; standalone