### PR TITLE
Fedora 23: remove autotools-devel, add gcc-c++

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ executing the following command should suffice:
 
 On Fedora/CentOS/RHEL OS, executing the following command should suffice:
 
-    $ sudo yum install autoconf automake autotools-devel libmpc-devel mpfr-devel gmp-devel gawk  bison flex texinfo patchutils gcc 
+    $ sudo yum install autoconf automake libmpc-devel mpfr-devel gmp-devel gawk  bison flex texinfo patchutils gcc gcc-c++
 
 On OS X, you can use [Homebrew](http://brew.sh) to install the dependencies:
 


### PR DESCRIPTION
Had a failure to build on a pretty fresh Fedora 23 install because I was missing `g++`.  Unclear how we want the instructions to be handled ongoing; older RPM distributions might still need `autotools-devel`.