### PR TITLE
Use RISCVEL and not _RISCVEL in newlib/patches

### DIFF
--- a/patches/newlib
+++ b/patches/newlib
@@ -51,7 +51,7 @@
  #endif
  
 +#ifdef __riscv__
-+# ifdef _RISCVEL
++# ifdef RISCVEL
 +#  define __IEEE_LITTLE_ENDIAN
 +# else
 +#  define __IEEE_BIG_ENDIAN


### PR DESCRIPTION
Fixes #127.

`_RISCVEL` sill in use by gcc/libgcc/config/riscv/t-tpbit.