### PR TITLE
Change dynamic linker paths to avoid clashes between RV64 and RV32

### DIFF
--- a/binutils/bfd/elfnn-riscv.c
+++ b/binutils/bfd/elfnn-riscv.c
@@ -41,10 +41,10 @@
 #define RISCV_ELF_WORD_BYTES (1 << RISCV_ELF_LOG_WORD_BYTES)
 
 /* The name of the dynamic interpreter.  This is put in the .interp
-   section.  */
+   section.  GCC always overrides these paths.  */
 
-#define ELF64_DYNAMIC_INTERPRETER "/lib/ld.so.1"
-#define ELF32_DYNAMIC_INTERPRETER "/lib32/ld.so.1"
+#define ELF64_DYNAMIC_INTERPRETER "/lib/ld-linux-riscv64ifd_lp64.so.1"
+#define ELF32_DYNAMIC_INTERPRETER "/lib/ld-linux-riscv32ifd_ilp32.so.1"
 
 #define ELF_ARCH			bfd_arch_riscv
 #define ELF_TARGET_ID			RISCV_ELF_DATA

--- a/binutils/ld/emulparams/elf32lriscv.sh
+++ b/binutils/ld/emulparams/elf32lriscv.sh
@@ -1,2 +1,3 @@
 . ${srcdir}/emulparams/elf32lriscv-defs.sh
 OUTPUT_FORMAT="elf32-littleriscv"
+ELF_INTERPRETER_NAME=\"/lib/ld-linux-riscv64ifd_ilp32.so.1\"

--- a/binutils/ld/emulparams/elf64lriscv.sh
+++ b/binutils/ld/emulparams/elf64lriscv.sh
@@ -1,2 +1,3 @@
 . ${srcdir}/emulparams/elf64lriscv-defs.sh
 OUTPUT_FORMAT="elf64-littleriscv"
+ELF_INTERPRETER_NAME=\"/lib/ld-linux-riscv64ifd_lp64.so.1\"

--- a/gcc/gcc/config/riscv/linux.h
+++ b/gcc/gcc/config/riscv/linux.h
@@ -35,7 +35,7 @@ along with GCC; see the file COPYING3.  If not see
 #undef SUBTARGET_CPP_SPEC
 #define SUBTARGET_CPP_SPEC "%{posix:-D_POSIX_SOURCE} %{pthread:-D_REENTRANT}"
 
-#define GLIBC_DYNAMIC_LINKER "/lib/ld.so.1"
+#define GLIBC_DYNAMIC_LINKER "/lib/ld-linux-riscv32ifd_ilp32.so.1"
 
 /* Borrowed from sparc/linux.h */
 #undef LINK_SPEC

--- a/gcc/gcc/config/riscv/linux64.h
+++ b/gcc/gcc/config/riscv/linux64.h
@@ -27,8 +27,8 @@ along with GCC; see the file COPYING3.  If not see
 %{!shared: \
   %{profile:-lc_p} %{!profile:-lc}}"
 
-#define GLIBC_DYNAMIC_LINKER32 "/lib32/ld.so.1"
-#define GLIBC_DYNAMIC_LINKER64 "/lib/ld.so.1"
+#define GLIBC_DYNAMIC_LINKER32 "/lib/ld-linux-riscv64ifd_ilp32.so.1"
+#define GLIBC_DYNAMIC_LINKER64 "/lib/ld-linux-riscv64ifd_lp64.so.1"
 
 #undef LINK_SPEC
 #define LINK_SPEC "\

--- a/glibc/sysdeps/unix/sysv/linux/riscv/rv32/ldconfig.h
+++ b/glibc/sysdeps/unix/sysv/linux/riscv/rv32/ldconfig.h
@@ -19,8 +19,7 @@
 #include <sysdeps/generic/ldconfig.h>
 
 #define SYSDEP_KNOWN_INTERPRETER_NAMES \
-  { "/lib/ld-linux-riscv64ifd_ilp32.so.1", FLAG_ELF_LIBC6 }, \
-  { "/lib/ld-linux-riscv64ifd_lp64.so.1", FLAG_ELF_LIBC6 }, \
+  { "/lib/ld-linux-riscv32ifd_ilp32.so.1", FLAG_ELF_LIBC6 }, \
   { "/lib32/ld.so.1", FLAG_ELF_LIBC6 }, \
   { "/lib/ld.so.1", FLAG_ELF_LIBC6 },
 #define SYSDEP_KNOWN_LIBRARY_NAMES \


### PR DESCRIPTION
In addition to pull request #130 (not yet accepted, so probably this one should be accepted only if/after the other one is), this fixes a minor inconsistency between declaration and definition of `riscv_{gpr,fpr}_names_{numeric,abi}`.
