### PR TITLE
Use NGPR/NFPR in riscv_{gpr,fpr}_names_{numeric,abi}, instead of 32

### DIFF
--- a/binutils/opcodes/riscv-opc.c
+++ b/binutils/opcodes/riscv-opc.c
@@ -26,7 +26,7 @@
 
 /* Register names used by gas and objdump.  */
 
-const char * const riscv_gpr_names_numeric[32] =
+const char * const riscv_gpr_names_numeric[NGPR] =
 {
   "x0",   "x1",   "x2",   "x3",   "x4",   "x5",   "x6",   "x7",
   "x8",   "x9",   "x10",  "x11",  "x12",  "x13",  "x14",  "x15",
@@ -34,14 +34,14 @@ const char * const riscv_gpr_names_numeric[32] =
   "x24",  "x25",  "x26",  "x27",  "x28",  "x29",  "x30",  "x31"
 };
 
-const char * const riscv_gpr_names_abi[32] = {
+const char * const riscv_gpr_names_abi[NGPR] = {
   "zero", "ra", "sp",  "gp",  "tp", "t0",  "t1",  "t2",
   "s0",   "s1", "a0",  "a1",  "a2", "a3",  "a4",  "a5",
   "a6",   "a7", "s2",  "s3",  "s4", "s5",  "s6",  "s7",
   "s8",   "s9", "s10", "s11", "t3", "t4",  "t5",  "t6"
 };
 
-const char * const riscv_fpr_names_numeric[32] =
+const char * const riscv_fpr_names_numeric[NFPR] =
 {
   "f0",   "f1",   "f2",   "f3",   "f4",   "f5",   "f6",   "f7",
   "f8",   "f9",   "f10",  "f11",  "f12",  "f13",  "f14",  "f15",
@@ -49,7 +49,7 @@ const char * const riscv_fpr_names_numeric[32] =
   "f24",  "f25",  "f26",  "f27",  "f28",  "f29",  "f30",  "f31"
 };
 
-const char * const riscv_fpr_names_abi[32] = {
+const char * const riscv_fpr_names_abi[NFPR] = {
   "ft0", "ft1", "ft2",  "ft3",  "ft4", "ft5", "ft6",  "ft7",
   "fs0", "fs1", "fa0",  "fa1",  "fa2", "fa3", "fa4",  "fa5",
   "fa6", "fa7", "fs2",  "fs3",  "fs4", "fs5", "fs6",  "fs7",


### PR DESCRIPTION
To be consistent with the declaration in binutils/include/opcode/riscv.h