### PR TITLE
Update GCC to 6.1.0

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -3,7 +3,7 @@ builddir := @abs_top_builddir@
 INSTALL_DIR := @prefix@
 
 PACKAGES := binutils gcc glibc newlib
-gcc_version := 5.3.0
+gcc_version := 6.1.0
 binutils_version := 2.26
 glibc_version := 2.23
 newlib_version := 2.2.0
@@ -164,6 +164,7 @@ stamps/build-glibc-linux$(XLEN)$(MULTILIB): src/glibc stamps/build-gcc-linux-sta
 		--prefix=/usr \
 		libc_cv_forced_unwind=yes \
 		libc_cv_c_cleanup=yes \
+		--disable-werror \
 		--enable-shared \
 		--enable-__thread \
 		$(MULTILIB_FLAGS) \

--- a/gcc/gcc/config/riscv/riscv.h
+++ b/gcc/gcc/config/riscv/riscv.h
@@ -341,7 +341,7 @@ along with GCC; see the file COPYING3.  If not see
 
 /* Define if operations between registers always perform the operation
    on the full register even if a narrower mode is specified.  */
-#define WORD_REGISTER_OPERATIONS
+#define WORD_REGISTER_OPERATIONS 1
 
 /* When in 64-bit mode, move insns will sign extend SImode and CCmode
    moves.  All other references are zero extended.  */
@@ -373,7 +373,7 @@ along with GCC; see the file COPYING3.  If not see
    && ((CLASS1) == FP_REGS) != ((CLASS2) == FP_REGS))
 
 /* Define if loading short immediate values into registers sign extends.  */
-#define SHORT_IMMEDIATES_SIGN_EXTEND
+#define SHORT_IMMEDIATES_SIGN_EXTEND 1
 
 /* Standard register usage.  */
 
@@ -633,7 +633,7 @@ enum reg_class
 
 /* Stack layout; function entry, exit and calling.  */
 
-#define STACK_GROWS_DOWNWARD
+#define STACK_GROWS_DOWNWARD 1
 
 #define FRAME_GROWS_DOWNWARD 1
 

--- a/gcc/gcc/config/riscv/riscv.md
+++ b/gcc/gcc/config/riscv/riscv.md
@@ -2373,7 +2373,7 @@
 {
   int i;
 
-  emit_call_insn (GEN_CALL (operands[0], const0_rtx, NULL, const0_rtx));
+  emit_call_insn (gen_call (operands[0], const0_rtx, NULL, const0_rtx));
 
   for (i = 0; i < XVECLEN (operands[2], 0); i++)
     {

--- a/gcc/gcc/config/riscv/sync.md
+++ b/gcc/gcc/config/riscv/sync.md
@@ -152,13 +152,13 @@
     {
       rtx difference = gen_rtx_MINUS (<MODE>mode, operands[1], operands[3]);
       compare = gen_reg_rtx (<MODE>mode);
-      emit_insn (gen_rtx_SET (VOIDmode, compare, difference));
+      emit_insn (gen_rtx_SET (compare, difference));
     }
 
   rtx eq = gen_rtx_EQ (<MODE>mode, compare, const0_rtx);
   rtx result = gen_reg_rtx (<MODE>mode);
-  emit_insn (gen_rtx_SET (VOIDmode, result, eq));
-  emit_insn (gen_rtx_SET (VOIDmode, operands[0], gen_lowpart (SImode, result)));
+  emit_insn (gen_rtx_SET (result, eq));
+  emit_insn (gen_rtx_SET (operands[0], gen_lowpart (SImode, result)));
   DONE;
 })
 

--- a/patches/gcc
+++ b/patches/gcc
@@ -157,17 +157,6 @@
  #elif defined(__RX__)
  /* No pic register.  */
  #elif defined(__s390__)
---- original-gcc/gcc/testsuite/gcc.dg/20040813-1.c
-+++ gcc/gcc/testsuite/gcc.dg/20040813-1.c
-@@ -2,7 +2,7 @@
- /* Contributed by Devang Patel  <dpatel@apple.com>  */
- 
- /* { dg-do compile } */
--/* { dg-skip-if "No stabs" { aarch64*-*-* mmix-*-* *-*-aix* alpha*-*-* hppa*64*-*-* ia64-*-* tile*-*-* nios2-*-* *-*-vxworks* nvptx-*-* } { "*" } { "" } } */
-+/* { dg-skip-if "No stabs" { aarch64*-*-* mmix-*-* *-*-aix* alpha*-*-* hppa*64*-*-* ia64-*-* riscv*-*-* tile*-*-* nios2-*-* *-*-vxworks* nvptx-*-* } { "*" } { "" } } */
- /* { dg-options "-gstabs" } */
- 
- int
 --- original-gcc/gcc/testsuite/gcc.dg/stack-usage-1.c
 +++ gcc/gcc/testsuite/gcc.dg/stack-usage-1.c
 @@ -61,6 +61,8 @@
@@ -216,8 +205,8 @@
  rs6000-ibm-aix4.[3456789]* | powerpc-ibm-aix4.[3456789]*)
  	md_unwind_header=rs6000/aix-unwind.h
  	tmake_file="t-fdpbit rs6000/t-ppc64-fp rs6000/t-slibgcc-aix rs6000/t-ibm-ldouble"
---- original-gcc/libsanitizer/asan/asan_linux.cc
-+++ gcc/libsanitizer/asan/asan_linux.cc
+--- original-gcc/libsanitizer/sanitizer_common/sanitizer_linux.cc
++++ gcc/libsanitizer/sanitizer_common/sanitizer_linux.cc
 @@ -213,6 +213,11 @@ void GetPcSpBp(void *context, uptr *pc,
    *pc = ucontext->uc_mcontext.gregs[31];
    *bp = ucontext->uc_mcontext.gregs[30];
@@ -299,27 +288,3 @@ diff -ru gcc-5.1.0.orig/libsanitizer/sanitizer_common/sanitizer_platform_limits_
    const unsigned struct___old_kernel_stat_sz = 0;
  #elif !defined(__sparc__)
    const unsigned struct___old_kernel_stat_sz = 32;
---- original-gcc/libstdc++-v3/configure
-+++ gcc/libstdc++-v3/configure
-@@ -16646,7 +16646,7 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
-   # Long term, -std=c++0x could be even better, could manage to explicitly
-   # request C99 facilities to the underlying C headers.
-   ac_save_CXXFLAGS="$CXXFLAGS"
--  CXXFLAGS="$CXXFLAGS -std=c++98"
-+  CXXFLAGS="$CXXFLAGS -std=gnu++98"
-   ac_save_LIBS="$LIBS"
-   ac_save_gcc_no_link="$gcc_no_link"
- 
-@@ -17268,9 +17268,11 @@ rm -f core conftest.err conftest.$ac_obj
- $as_echo "$glibcxx_cv_c99_wchar" >&6; }
-   fi
- 
-+  # For newlib, don't check complex since missing c99 functions, but
-+  #   rest of c99 stuff is there so don't loose it
-   # Option parsed, now set things appropriately.
-   if test x"$glibcxx_cv_c99_math" = x"no" ||
--     test x"$glibcxx_cv_c99_complex" = x"no" ||
-+     # test x"$glibcxx_cv_c99_complex" = x"no" ||
-      test x"$glibcxx_cv_c99_stdio" = x"no" ||
-      test x"$glibcxx_cv_c99_stdlib" = x"no" ||
-      test x"$glibcxx_cv_c99_wchar" = x"no"; then


### PR DESCRIPTION
In addition to some small changes, here's the bigger ones:

* gen_rtx_SET no longer takes a VOIDmode, apparently that was the only
  valid argument in that position so it's been dropped.

* GEN_CALL is now gen_call.

* The #defines in riscv.h need to be defined to 1, not just defined,
  since they're now used in "if ()" statements.

* glibc is passed "--disable-werror", since the new GCC throws a bunch
  of pointless errors like "misleading indentation".  This is all in
  upstream glibc code.