### PR TITLE
Improve handling of --with-arch in configure.ac

### DIFF
--- a/configure
+++ b/configure
@@ -654,9 +654,9 @@ ac_user_opts='
 enable_option_checking
 enable_linux
 with_xlen
-with_arch
 enable_atomic
 enable_float
+with_arch
 enable_multilib
 '
       ac_precious_vars='build_alias
@@ -1289,7 +1289,7 @@ Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
   --with-xlen=XLEN        Set XLEN, the X-register bit width (default is 64)
-  --with-arch=IMAFD       Sets the base RISC-V ISA, defaults to IMAFD
+  --with-arch=RV64IMAFD   Sets the base RISC-V ISA, defaults to RV64IMAFD
 
 Some influential environment variables:
   CC          C compiler command
@@ -2735,6 +2735,69 @@ $as_echo "$ac_cv_path_FGREP" >&6; }
  FGREP="$ac_cv_path_FGREP"
 
 
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for grep that handles long lines and -e" >&5
+$as_echo_n "checking for grep that handles long lines and -e... " >&6; }
+if ${ac_cv_path_GREP+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -z "$GREP"; then
+  ac_path_GREP_found=false
+  # Loop through the user's path and test for each of PROGNAME-LIST
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH$PATH_SEPARATOR/usr/xpg4/bin
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_prog in grep ggrep; do
+    for ac_exec_ext in '' $ac_executable_extensions; do
+      ac_path_GREP="$as_dir/$ac_prog$ac_exec_ext"
+      as_fn_executable_p "$ac_path_GREP" || continue
+# Check for GNU ac_path_GREP and select it if it is found.
+  # Check for GNU $ac_path_GREP
+case `"$ac_path_GREP" --version 2>&1` in
+*GNU*)
+  ac_cv_path_GREP="$ac_path_GREP" ac_path_GREP_found=:;;
+*)
+  ac_count=0
+  $as_echo_n 0123456789 >"conftest.in"
+  while :
+  do
+    cat "conftest.in" "conftest.in" >"conftest.tmp"
+    mv "conftest.tmp" "conftest.in"
+    cp "conftest.in" "conftest.nl"
+    $as_echo 'GREP' >> "conftest.nl"
+    "$ac_path_GREP" -e 'GREP$' -e '-(cannot match)-' < "conftest.nl" >"conftest.out" 2>/dev/null || break
+    diff "conftest.out" "conftest.nl" >/dev/null 2>&1 || break
+    as_fn_arith $ac_count + 1 && ac_count=$as_val
+    if test $ac_count -gt ${ac_path_GREP_max-0}; then
+      # Best one so far, save it but keep looking for a better one
+      ac_cv_path_GREP="$ac_path_GREP"
+      ac_path_GREP_max=$ac_count
+    fi
+    # 10*(2^10) chars as input seems more than enough
+    test $ac_count -gt 10 && break
+  done
+  rm -f conftest.in conftest.tmp conftest.nl conftest.out;;
+esac
+
+      $ac_path_GREP_found && break 3
+    done
+  done
+  done
+IFS=$as_save_IFS
+  if test -z "$ac_cv_path_GREP"; then
+    as_fn_error $? "no acceptable grep could be found in $PATH$PATH_SEPARATOR/usr/xpg4/bin" "$LINENO" 5
+  fi
+else
+  ac_cv_path_GREP=$GREP
+fi
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_path_GREP" >&5
+$as_echo "$ac_cv_path_GREP" >&6; }
+ GREP="$ac_cv_path_GREP"
+
+
 
 # Extract the first word of "bash", so it can be a program name with args.
 set dummy bash; ac_word=$2
@@ -3152,19 +3215,58 @@ else
 fi
 
 
-
-# Check whether --with-arch was given.
-if test "${with_arch+set}" = set; then :
-  withval=$with_arch; WITH_ARCH=--with-arch=$withval
-
-fi
-
-
 # Check whether --enable-atomic was given.
 if test "${enable_atomic+set}" = set; then :
   enableval=$enable_atomic;
 else
   enable_atomic=yes
+
+fi
+
+
+# Check whether --enable-float was given.
+if test "${enable_float+set}" = set; then :
+  enableval=$enable_float;
+else
+  enable_float=yes
+
+fi
+
+
+
+
+
+
+
+
+
+
+
+# Check whether --with-arch was given.
+if test "${with_arch+set}" = set; then :
+  withval=$with_arch; if echo "$withval" | $GREP -qE "^RV32"; then :
+  XLEN=32
+
+fi
+	 if echo "$withval" | $GREP -qE "^RV64"; then :
+  XLEN=64
+
+fi
+
+	 if echo "$withval" | $GREP -qE "^RV(32|64).*A"; then :
+  enable_atomic=yes
+else
+  enable_atomic=no
+fi
+
+	 if echo "$withval" | $GREP -qE "^RV(32|64).*F"; then :
+  enable_float=yes
+else
+  enable_float=no
+fi
+
+
+	 WITH_ARCH=--with-arch=$withval
 
 fi
 
@@ -3175,15 +3277,6 @@ else
   atomic_cflags=-mno-atomic
 
 fi
-
-# Check whether --enable-float was given.
-if test "${enable_float+set}" = set; then :
-  enableval=$enable_float;
-else
-  enable_float=yes
-
-fi
-
 
 if test "x$enable_float" != xno; then :
   float_cflags=-mhard-float

--- a/configure.ac
+++ b/configure.ac
@@ -2,6 +2,7 @@ AC_INIT(riscv-toolchain, 1.0)
 
 AC_PROG_CC
 AC_PROG_FGREP
+AC_PROG_GREP
 
 AC_PATH_PROG([BASH], [bash],
 	[AC_MSG_ERROR([bash not found])])
@@ -56,13 +57,6 @@ AC_ARG_WITH(xlen,
 	AC_SUBST(XLEN, 64)
 	)
 
-AC_ARG_WITH(arch,
-	[AS_HELP_STRING([--with-arch=IMAFD],
-		[Sets the base RISC-V ISA, defaults to IMAFD])],
-	AC_SUBST(WITH_ARCH, --with-arch=$withval),
-	AC_SUBST(WITH_ARCH,)
-	)
-
 AC_ARG_ENABLE(atomic,
 	[AS_HELP_STRING([--disable-atomic],
 		[disable use of atomic memory instructions in glibc @<:@--enable-atomic@:>@])],
@@ -70,16 +64,45 @@ AC_ARG_ENABLE(atomic,
 	[enable_atomic=yes]
 	)
 
-AS_IF([test "x$enable_atomic" != xno],
-        [],
-	[AC_SUBST(atomic_cflags,-mno-atomic)])
-
 AC_ARG_ENABLE(float,
 	[AS_HELP_STRING([--disable-float],
 		[use software floating point in glibc @<:@--enable-float@:>@])],
 	[],
 	[enable_float=yes]
 	)
+
+AC_DEFUN([MATCH_PATTERN], [echo "$1" | $GREP -qE "$2"])
+
+AC_DEFUN([GENERATE_EXTENSION],
+	[AS_IF([MATCH_PATTERN([$1], [^RV(32|64).*$2])],
+		[$3=yes],
+		[$3=no])]
+	)
+
+AC_DEFUN([PARSE_EXTENSIONS],
+	[GENERATE_EXTENSION([$1], A, enable_atomic)
+	 GENERATE_EXTENSION([$1], F, enable_float)]
+	)
+
+AC_DEFUN([PARSE_BASE_ARCH],
+	[AS_IF([MATCH_PATTERN([$1], [^RV32])],
+		AC_SUBST(XLEN, 32))
+	 AS_IF([MATCH_PATTERN([$1], [^RV64])],
+		AC_SUBST(XLEN, 64))]
+	)
+
+AC_ARG_WITH(arch,
+	[AS_HELP_STRING([--with-arch=RV64IMAFD],
+		[Sets the base RISC-V ISA, defaults to RV64IMAFD])],
+	[PARSE_BASE_ARCH([$withval])
+	 PARSE_EXTENSIONS([$withval])
+	 AC_SUBST(WITH_ARCH, --with-arch=$withval)],
+	[]
+	)
+
+AS_IF([test "x$enable_atomic" != xno],
+        [],
+	[AC_SUBST(atomic_cflags,-mno-atomic)])
 
 AS_IF([test "x$enable_float" != xno],
 	    [AC_SUBST(float_cflags,-mhard-float)dnl


### PR DESCRIPTION
Remove the --enable-atomics and --enable-float flags and have
configure.ac generate flags values based on the specified arch string.