### PR TITLE
Add skeleton travis-ci configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+addons:
+  apt:
+    packages:
+      - autoconf
+      - automake
+      - autotools-dev
+      - bc
+      - bison
+      - build-essential
+      - curl
+      - flex
+      - gawk
+      - gperf
+      - libgmp-dev
+      - libmpc-dev
+      - libmpfr-dev
+      - libtool
+      - patchutils
+      - texinfo
+install: true
+script:
+  - ./configure --prefix=/tmp/build-default
+  - make


### PR DESCRIPTION
Not sure how popular this suggestion will be, but here's the skeleton for getting Travis running on the toolchain.  There's no testing beyond just getting it built at this point.