### PR TITLE
Makefile.in: Re-enable GDB

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -123,7 +123,6 @@ stamps/build-binutils-linux: $(srcdir)/riscv-binutils-gdb
 		--target=riscv$(XLEN)-unknown-linux-gnu \
 		--prefix=$(INSTALL_DIR) \
 		--with-sysroot=$(SYSROOT) \
-		--disable-gdb \
 		--disable-sim \
 		$(BINUTILS_FLOAT_FLAGS) \
 		$(MULTILIB_FLAGS) \


### PR DESCRIPTION
I haven't tested this patch locally, only on Travis-CI, but it seems to work.
Fixes riscv/riscv-tools#28 once the riscv-gnu-toolchain submodule is updated.