### PR TITLE
Pass disable-werror to binutils-gdb

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -124,6 +124,7 @@ stamps/build-binutils-linux: $(srcdir)/riscv-binutils-gdb
 		--disable-sim \
 		$(BINUTILS_FLOAT_FLAGS) \
 		$(MULTILIB_FLAGS) \
+		--disable-werror \
 		--disable-nls
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install


### PR DESCRIPTION
GCC 6.1.1 throws several warnings, breaking the build.
Other targets have --disable-werror already, but not gdb.

```
.../riscv-binutils-gdb/gdb/symfile.c: In function ‘find_pc_overlay’:
.../riscv-binutils-gdb/gdb/symfile.c:3295:6: error: suggest explicit braces to avoid ambiguous ‘else’ [-Werror=parentheses]
   if (overlay_debugging)
      ^
.../riscv-binutils-gdb/gdb/symfile.c: In function ‘find_pc_mapped_section’:
.../riscv-binutils-gdb/gdb/symfile.c:3322:6: error: suggest explicit braces to avoid ambiguous ‘else’ [-Werror=parentheses]
   if (overlay_debugging)
      ^
.../riscv-binutils-gdb/gdb/symfile.c: In function ‘list_overlays_command’:
.../riscv-binutils-gdb/gdb/symfile.c:3340:6: error: suggest explicit braces to avoid ambiguous ‘else’ [-Werror=parentheses]
   if (overlay_debugging)
      ^
```