### PR TITLE
newlib: use brk(0) to get initial program break

### DIFF
--- a/newlib/libgloss/riscv/syscalls.c
+++ b/newlib/libgloss/riscv/syscalls.c
@@ -436,11 +436,15 @@ long sysconf(int name)
 
 void* sbrk(ptrdiff_t incr)
 {
-  extern unsigned char _end[]; // Defined by linker
   static unsigned long heap_end;
 
-  if (heap_end == 0)
-    heap_end = (long)_end;
+  if (heap_end == 0) {
+    long brk = syscall_errno(SYS_brk, 0, 0, 0, 0);
+    if(brk == -1)
+	    return (void*)-1;
+    heap_end = brk;
+  }
+
   if (syscall_errno(SYS_brk, heap_end + incr, 0, 0, 0) != heap_end + incr)
     return (void*)-1;
 


### PR DESCRIPTION
There are no guarantees that the break going to be located exactly
at the _end, but brk(0) is guaranteed to return its current value.

QEMU ELF loader moves the initial break up to the next page boundary,
disabling sbrk-based malloc for any allocations smaller than
the adjustment made. And ASLR may do even worse.