### PR TITLE
Add support for run testsuite with qemu

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -275,6 +275,13 @@ check-gcc-newlib: stamps/build-gcc-newlib
 	cd build-gcc-newlib && \
 	$(MAKE) check-gcc "RUNTESTFLAGS=--target_board=riscv-sim"
 
+check-gcc-linux: stamps/build-gcc-linux-stage2
+	export PATH=$(srcdir)/scripts/wrapper/qemu:$(INSTALL_DIR)/bin:$(PATH) && \
+	export DEJAGNULIBS=$(srcdir)/riscv-dejagnu && \
+	export RISC_V_SYSROOT=$(SYSROOT) && \
+	cd build-gcc-linux-stage2 && \
+	$(MAKE) check-gcc "RUNTESTFLAGS=--target_board=riscv-sim"
+
 clean:
 	rm -rf build-* $(addprefix src/,$(PACKAGES)) stamps
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -16,6 +16,12 @@ WITH_ARCH ?= @WITH_ARCH@
 MULTILIB ?=
 SYSROOT := $(INSTALL_DIR)/sysroot
 
+ifeq ($(XLEN),32)
+LIBDIR := lib32
+else
+LIBDIR := lib
+endif
+
 SHELL := /bin/sh
 AWK := @GAWK@
 SED := @GSED@
@@ -222,6 +228,7 @@ stamps/build-gcc-linux-stage2: $(srcdir)/riscv-gcc stamps/build-glibc-linux$(XLE
 		$(WITH_ARCH)
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
+	cp $(INSTALL_DIR)/riscv$(XLEN)-unknown-linux-gnu/$(LIBDIR)/lib*.so* $(SYSROOT)/usr/$(LIBDIR)
 	mkdir -p $(dir $@) && touch $@
 
 stamps/build-binutils-newlib: $(srcdir)/riscv-binutils-gdb

--- a/README.md
+++ b/README.md
@@ -82,9 +82,16 @@ configure.  See './configure --help' for more details.
 
 ### Test Suite
 
-The DejaGnu test suite has been ported to RISC-V.  This currently only runs in
-the GDB simulator, which doesn't support floating-point or Linux/glibc.  To
-test GCC, run the following commands:
+The DejaGnu test suite has been ported to RISC-V.  This can run with GDB
+simulator for elf toolchain or Qemu for linux toolchain, and GDB simulator
+doesn't support floating-point.
+To test GCC, run the following commands:
 
   ./configure --prefix=$RISCV --disable-float --disable-linux
+  make newlib
   make check-gcc-newlib
+
+  ./configure --prefix=$RISCV
+  make linux
+  # Need qemu-riscv32 or qemu-riscv64 in your `PATH`.
+  make check-gcc-linux

--- a/scripts/wrapper/qemu/riscv32-unknown-linux-gnu-run
+++ b/scripts/wrapper/qemu/riscv32-unknown-linux-gnu-run
@@ -1,0 +1,1 @@
+qemu-riscv32 -L ${RISC_V_SYSROOT} $*

--- a/scripts/wrapper/qemu/riscv64-unknown-linux-gnu-run
+++ b/scripts/wrapper/qemu/riscv64-unknown-linux-gnu-run
@@ -1,0 +1,1 @@
+qemu-riscv64 -L ${RISC_V_SYSROOT} $*


### PR DESCRIPTION
I have add support for run testsuite with qemu, we can run gcc testsuite for linux toolchain,
and able to testing hard float now!