### PR TITLE
Add --enable-gcc-checking to configure option

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -44,6 +44,7 @@ ATOMIC_CFLAGS := @atomic_cflags@
 BINUTILS_FLOAT_FLAGS := @binutils_float_flags@
 GCC_FLOAT_FLAGS := @gcc_float_flags@
 GLIBC_FLOAT_FLAGS := @glibc_float_flags@
+GCC_CHECKING_FLAGS := @gcc_checking@
 
 CFLAGS_FOR_TARGET := $(CFLAGS_FOR_TARGET_EXTRA) $(ATOMIC_CFLAGS)
 ASFLAGS_FOR_TARGET := $(ASFLAGS_FOR_TARGET_EXTRA)
@@ -197,6 +198,7 @@ stamps/build-gcc-linux-stage1: $(srcdir)/riscv-gcc stamps/build-binutils-linux \
 		--disable-nls \
 		--disable-bootstrap \
 		$(GCC_FLOAT_FLAGS) \
+		$(GCC_CHECKING_FLAGS) \
 		$(MULTILIB_FLAGS) \
 		$(WITH_ARCH)
 	$(MAKE) -C $(notdir $@) inhibit-libc=true all-gcc
@@ -222,6 +224,7 @@ stamps/build-gcc-linux-stage2: $(srcdir)/riscv-gcc stamps/build-glibc-linux$(XLE
 		--disable-nls \
 		--disable-bootstrap \
 		$(GCC_FLOAT_FLAGS) \
+		$(GCC_CHECKING_FLAGS) \
 		$(MULTILIB_FLAGS) \
 		$(WITH_ARCH)
 	$(MAKE) -C $(notdir $@)
@@ -267,6 +270,7 @@ stamps/build-gcc-newlib: src/newlib-gcc stamps/build-binutils-newlib
 		--disable-libgomp \
 		--disable-nls \
 		$(GCC_FLOAT_FLAGS) \
+		$(GCC_CHECKING_FLAGS) \
 		$(MULTILIB_FLAGS) \
 		$(WITH_ARCH)
 	$(MAKE) -C $(notdir $@) inhibit-libc=true

--- a/configure
+++ b/configure
@@ -584,6 +584,7 @@ PACKAGE_URL=''
 
 ac_subst_vars='LTLIBOBJS
 LIBOBJS
+gcc_checking
 multilib_flags
 glibc_float_flags
 gcc_float_flags
@@ -656,6 +657,7 @@ enable_atomic
 enable_float
 with_arch
 enable_multilib
+enable_gcc_checking
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1282,6 +1284,9 @@ Optional Features:
                           [--enable-float]
   --enable-multilib       build both RV32 and RV64 runtime libraries
                           [--disable-multilib]
+  --enable-gcc-checking   Enable gcc internal checking, it will make gcc very
+                          slow, only enable it when developing gcc
+                          [--disable-gcc-checking]
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -3300,6 +3305,22 @@ if test "x$enable_multilib" != xno; then :
 
 else
   multilib_flags=--disable-multilib
+
+fi
+
+# Check whether --enable-gcc-checking was given.
+if test "${enable_gcc_checking+set}" = set; then :
+  enableval=$enable_gcc_checking;
+else
+  enable_gcc_checking=yes
+
+fi
+
+if test "x$enable_gcc_checking" != xno; then :
+  gcc_checking=--enable-checking=yes
+
+else
+  gcc_checking=--enable-checking=release
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -122,6 +122,16 @@ AS_IF([test "x$enable_multilib" != xno],
         [AC_SUBST(multilib_flags,)],
 	[AC_SUBST(multilib_flags,--disable-multilib)])
 
+AC_ARG_ENABLE(gcc-checking,
+        [AS_HELP_STRING([--enable-gcc-checking],
+		[Enable gcc internal checking, it will make gcc very slow, only enable it when developing gcc @<:@--disable-gcc-checking@:>@])],
+        [],
+        [enable_gcc_checking=yes]
+        )
+AS_IF([test "x$enable_gcc_checking" != xno],
+	[AC_SUBST(gcc_checking, --enable-checking=yes)],
+	[AC_SUBST(gcc_checking, --enable-checking=release)])
+
 AC_CONFIG_FILES([Makefile])
 AC_CONFIG_FILES([scripts/wrapper/awk/awk], [chmod +x scripts/wrapper/awk])
 AC_CONFIG_FILES([scripts/wrapper/sed/sed], [chmod +x scripts/wrapper/sed])


### PR DESCRIPTION
--enable-gcc-checking can pass --enable-checking=yes to gcc, it can enable lots of internal checking for gcc, very usefully when developing gcc.