### PR TITLE
Several improve for build script 

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -199,7 +199,7 @@ stamps/build-binutils-newlib: $(srcdir)/riscv-binutils-gdb
 	cd $(notdir $@) && $</configure \
 		--target=riscv$(XLEN)-unknown-elf \
 		--prefix=$(INSTALL_DIR) \
-		--enable-tls \
+		--disable-tls \
 		--disable-werror
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
@@ -222,7 +222,7 @@ stamps/build-gcc-newlib: src/newlib-gcc stamps/build-binutils-newlib
 		--prefix=$(INSTALL_DIR) \
 		--disable-shared \
 		--disable-threads \
-		--enable-tls \
+		--disable-tls \
 		--enable-languages=c,c++ \
 		--with-system-zlib \
 		--with-newlib \

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ simulator for elf toolchain or Qemu for linux toolchain, and GDB simulator
 doesn't support floating-point.
 To test GCC, run the following commands:
 
-    ./configure --prefix=$RISCV --disable-float --disable-linux
+    ./configure --prefix=$RISCV --disable-linux --with-arch=rv64ima # or --with-arch=rv32ima
     make newlib
     make check-gcc-newlib
 

--- a/configure
+++ b/configure
@@ -3224,13 +3224,34 @@ fi
 
 # Check whether --with-abi was given.
 if test "${with_abi+set}" = set; then :
-  withval=$with_abi; WITH_ABI=--with-abi=$withval
-
+  withval=$with_abi;
 else
-  WITH_ABI=--with-abi=lp64d
-
+  with_abi=default
 
 fi
+
+
+if test "x$with_abi" == xdefault; then :
+  case $with_arch in #(
+  *rv64g | *rv64*d*) :
+    with_abi=lp64d ;; #(
+  *rv64*f*) :
+    with_abi=lp64f ;; #(
+  *rv64*) :
+    with_abi=lp64 ;; #(
+  *rv32g | *rv32*d*) :
+    with_abi=ilp32d ;; #(
+  *rv32*f*) :
+    with_abi=ilp32f ;; #(
+  *rv32*) :
+    with_abi=ilp32 ;; #(
+  *) :
+    as_fn_error $? "Unknown arch" "$LINENO" 5
+	 ;;
+esac
+fi
+
+WITH_ABI=--with-abi=$with_abi
 
 
 # Check whether --enable-multilib was given.

--- a/configure.ac
+++ b/configure.ac
@@ -67,9 +67,22 @@ AC_ARG_WITH(arch,
 AC_ARG_WITH(abi,
 	[AS_HELP_STRING([--with-abi=lp64d],
 		[Sets the base RISC-V ABI, defaults to lp64d])],
-	AC_SUBST(WITH_ABI, --with-abi=$withval),
-	AC_SUBST(WITH_ABI, --with-abi=lp64d)
+	[],
+	[with_abi=default]
 	)
+
+AS_IF([test "x$with_abi" == xdefault],
+	[AS_CASE([$with_arch],
+		[*rv64g | *rv64*d*], [with_abi=lp64d],
+		[*rv64*f*], [with_abi=lp64f],
+		[*rv64*], [with_abi=lp64],
+		[*rv32g | *rv32*d*], [with_abi=ilp32d],
+		[*rv32*f*], [with_abi=ilp32f],
+		[*rv32*], [with_abi=ilp32],
+		[AC_MSG_ERROR([Unknown arch])]
+	)])
+
+AC_SUBST(WITH_ABI, --with-abi=$with_abi)
 
 AC_ARG_ENABLE(multilib,
 	[AS_HELP_STRING([--enable-multilib],


### PR DESCRIPTION
1. Auto detect value for --with-abi, it's make configure --with-arch=rv32g can get right abi setting without specify  --with-abi
2. Update instruction for check-gcc-newlib.
3. Update configure option for newlib toolchain.