### PR TITLE
Improve error message for unavailable newlib multilibs

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -212,6 +212,8 @@ src/newlib-gcc: $(srcdir)/riscv-gcc
 	cp -a $</include/. $@.tmp/include
 	mv $@.tmp $@
 
+# For some reason, newlib builds a "default" library set even when
+# multilibs are enabled.  Purge it after completing a multilib build.
 stamps/build-gcc-newlib: src/newlib-gcc stamps/build-binutils-newlib
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
@@ -236,6 +238,7 @@ stamps/build-gcc-newlib: src/newlib-gcc stamps/build-binutils-newlib
 		$(WITH_ARCH)
 	$(MAKE) -C $(notdir $@) inhibit-libc=true
 	$(MAKE) -C $(notdir $@) install
+	$(if $(findstring enable,$(MULTILIB_FLAGS)),rm -f $(INSTALL_DIR)/riscv$(XLEN)-unknown-elf/lib/*.*,)
 	mkdir -p $(dir $@) && touch $@
 
 .PHONY: check-gcc-newlib


### PR DESCRIPTION
For some reason, a Newlib multilib build includes a "default" library
in addition to the multilibs ones.  This results in confounding error
messages when an invalid multilib is requested on the GCC command line.
Now, it reports a more sensible "cannot find -lc".