### PR TITLE
Fix --with-headers= path for newlib toolchain

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -252,14 +252,13 @@ stamps/build-gcc-newlib-stage2: $(srcdir)/riscv-gcc stamps/build-newlib
 	cd $(notdir $@) && $</configure \
 		--target=riscv$(XLEN)-unknown-elf \
 		--prefix=$(INSTALL_DIR) \
-		--without-headers \
 		--disable-shared \
 		--disable-threads \
 		--enable-languages=c,c++ \
 		--with-system-zlib \
 		--enable-tls \
 		--with-newlib \
-		--with-headers=$(INSTALL_DIR)/include \
+		--with-headers=$(INSTALL_DIR)/riscv$(XLEN)-unknown-elf/include \
 		--disable-libmudflap \
 		--disable-libssp \
 		--disable-libquadmath \


### PR DESCRIPTION
Wrong --with-headers= path will cause libgcov build incorrectly.