### PR TITLE
Don't require sudo on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 addons:
   apt:
     sources:


### PR DESCRIPTION
I'm hoping this will speed up our builds a bit, as we'll no longer be
executing in a VM but instead in a container.