### PR TITLE
Allow users to override the tuples

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -45,8 +45,8 @@ ifeq ($(MULTILIB_NAMES),)
 endif
 
 make_tuple = riscv$(1)-unknown-$(2)
-LINUX_TUPLE := $(call make_tuple,$(XLEN),linux-gnu)
-NEWLIB_TUPLE := $(call make_tuple,$(XLEN),elf)
+LINUX_TUPLE  ?= $(call make_tuple,$(XLEN),linux-gnu)
+NEWLIB_TUPLE ?= $(call make_tuple,$(XLEN),elf)
 
 CFLAGS_FOR_TARGET := $(CFLAGS_FOR_TARGET_EXTRA) @cmodel@
 ASFLAGS_FOR_TARGET := $(ASFLAGS_FOR_TARGET_EXTRA) @cmodel@


### PR DESCRIPTION
A user just added RTEMS support to the GCC port (via newlib), which is
very similar to the existing newlib port but has a different tuple.
This patch allows users to override the tuples to build other targets if
they want to.