### PR TITLE
Add gdb testsuite

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -320,6 +320,12 @@ stamps/build-qemu: $(srcdir)/riscv-qemu
 	$(MAKE) -C $(notdir $@) install
 	date > $@
 
+check-gdb-newlib: stamps/build-gcc-newlib-stage2
+	export PATH=$(INSTALL_DIR)/bin:$(PATH) && \
+	export DEJAGNULIBS=$(srcdir)/riscv-dejagnu && \
+	cd build-binutils-newlib && \
+	$(MAKE) check-gdb "RUNTESTFLAGS=--target_board=riscv-sim"
+
 stamps/check-gcc-newlib: stamps/build-gcc-newlib-stage2 stamps/build-qemu
 	export PATH=$(srcdir)/scripts/wrapper/qemu:$(INSTALL_DIR)/bin:$(PATH) && \
 	export DEJAGNULIBS=$(srcdir)/riscv-dejagnu && \


### PR DESCRIPTION
It's use gdb simulator to run testsuite, the result seems a little...terrible now.

```
		=== gdb Summary ===

# of expected passes		9179
# of unexpected failures	3761
# of expected failures		23
# of known failures		19
# of unresolved testcases	151
# of untested testcases		227
# of unsupported tests		264
```