### PR TITLE
Build native toolchain

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -58,6 +58,7 @@ CONFIGURE_HOST   = @configure_host@
 all: @default_target@
 newlib: stamps/build-gcc-newlib-stage2
 linux: stamps/build-gcc-linux-stage2
+linux-native: stamps/build-gcc-linux-native
 
 .PHONY: build-binutils build-gcc1 build-libc build-gcc2 build-qemu
 build-binutils: stamps/build-binutils-@default_target@
@@ -210,6 +211,49 @@ stamps/build-gcc-linux-stage2: $(srcdir)/riscv-gcc $(addprefix stamps/build-glib
 		--prefix=$(INSTALL_DIR) \
 		--with-sysroot=$(SYSROOT) \
 		@with_system_zlib@ \
+		--enable-shared \
+		--enable-tls \
+		--enable-languages=c,c++,fortran \
+		--disable-libmudflap \
+		--disable-libssp \
+		--disable-libquadmath \
+		--disable-nls \
+		--disable-bootstrap \
+		$(GCC_CHECKING_FLAGS) \
+		$(MULTILIB_FLAGS) \
+		$(WITH_ABI) \
+		$(WITH_ARCH)
+	$(MAKE) -C $(notdir $@)
+	$(MAKE) -C $(notdir $@) install
+	cp -a $(INSTALL_DIR)/$(LINUX_TUPLE)/lib* $(SYSROOT)
+	mkdir -p $(dir $@) && touch $@
+
+stamps/build-binutils-linux-native: $(srcdir)/riscv-binutils-gdb stamps/build-gcc-linux-stage2
+	rm -rf $@ $(notdir $@)
+	mkdir $(notdir $@)
+	cd $(notdir $@) && $</configure \
+		--host=$(LINUX_TUPLE) \
+		--target=$(LINUX_TUPLE) \
+		$(CONFIGURE_HOST) \
+		--prefix=$(INSTALL_DIR)/native \
+		$(MULTILIB_FLAGS) \
+		@with_guile@ \
+		--disable-werror \
+		--disable-nls
+	$(MAKE) -C $(notdir $@)
+	$(MAKE) -C $(notdir $@) install
+	mkdir -p $(dir $@) && touch $@
+
+stamps/build-gcc-linux-native: $(srcdir)/riscv-gcc stamps/build-gcc-linux-stage2 stamps/build-binutils-linux-native
+	if test -f $</contrib/download_prerequisites; then cd $< && ./contrib/download_prerequisites; fi
+	rm -rf $@ $(notdir $@)
+	mkdir $(notdir $@)
+	cd $(notdir $@) && $</configure \
+		--host=$(LINUX_TUPLE) \
+		--target=$(LINUX_TUPLE) \
+		$(CONFIGURE_HOST) \
+		--prefix=$(INSTALL_DIR)/native \
+		--without-system-zlib \
 		--enable-shared \
 		--enable-tls \
 		--enable-languages=c,c++,fortran \

--- a/Makefile.in
+++ b/Makefile.in
@@ -239,7 +239,8 @@ stamps/build-binutils-linux-native: $(srcdir)/riscv-binutils-gdb stamps/build-gc
 		$(MULTILIB_FLAGS) \
 		@with_guile@ \
 		--disable-werror \
-		--disable-nls
+		--disable-nls \
+		@enable_gdb@
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
@@ -262,6 +263,7 @@ stamps/build-gcc-linux-native: $(srcdir)/riscv-gcc stamps/build-gcc-linux-stage2
 		--disable-libquadmath \
 		--disable-nls \
 		--disable-bootstrap \
+                --with-native-system-header-dir=$(INSTALL_DIR)/native/include \
 		$(GCC_CHECKING_FLAGS) \
 		$(MULTILIB_FLAGS) \
 		$(WITH_ABI) \


### PR DESCRIPTION
Build rule for native toolchain with workaround for sys/sdt.h.

I had to disable gdb for the native toolchain to build after I rebased against master due to the same errors described at [https://github.com/riscv/riscv-binutils-gdb/issues/96](here). I couldn't work out where the typedefs got messed up between glibc, etc.