### PR TITLE
Enhance `make build-qemu`

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -367,7 +367,9 @@ stamps/build-qemu: $(srcdir)/riscv-qemu
 	mkdir $(notdir $@)
 	cd $(notdir $@) && $</configure \
 		--prefix=$(INSTALL_DIR) \
-		--target-list=riscv64-linux-user,riscv32-linux-user
+		--target-list=riscv64-linux-user,riscv32-linux-user \
+		--interp-prefix=$(INSTALL_DIR)/sysroot \
+		--python=python2
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@)


### PR DESCRIPTION
* Set the default interpreter prefix so users don't need to give `-L${sysroot}`.
* Explicitly use `python2` as on some distributions (e.g. Arch), the default python is 3.x.