### PR TITLE
Fix for compile on Windows/MSYS2 resolves #264

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,4 +1,5 @@
 srcdir := @abs_top_srcdir@
+relsrcdir := @top_srcdir@
 builddir := @abs_top_builddir@
 INSTALL_DIR := @prefix@
 
@@ -338,6 +339,7 @@ stamps/build-gcc-newlib-stage1: $(srcdir)/riscv-gcc stamps/build-binutils-newlib
 		--disable-libquadmath \
 		--disable-libgomp \
 		--disable-nls \
+		--src=../$(relsrcdir)/riscv-gcc \
 		$(GCC_CHECKING_FLAGS) \
 		$(MULTILIB_FLAGS) \
 		$(WITH_ABI) \
@@ -381,6 +383,7 @@ stamps/build-gcc-newlib-stage2: $(srcdir)/riscv-gcc stamps/build-newlib
 		--disable-libquadmath \
 		--disable-libgomp \
 		--disable-nls \
+		--src=../$(relsrcdir)/riscv-gcc \
 		$(GCC_CHECKING_FLAGS) \
 		$(MULTILIB_FLAGS) \
 		$(WITH_ABI) \


### PR DESCRIPTION
Propagates --src to gcc build as relative paths, otherwise there is issue building it on msys2 due to different handling of full paths on windows and posix systems.

Uses idea from @TM1234 but made it independent of build folder location.

