### PR TITLE
Add enable-obsolete-rpc option for glibc

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -195,6 +195,7 @@ endif
 		--prefix=/usr \
 		--disable-werror \
 		--enable-shared \
+		--enable-obsolete-rpc \
 		--with-headers=$(srcdir)/linux-headers/include \
 		$(MULTILIB_FLAGS) \
 		--enable-kernel=3.0.0 \


### PR DESCRIPTION
Enable this option to build the obsolete RPC implementation.
Some projects still uses these headers like: LTP, Busybox and so on.