### PR TITLE
Fix some msys2 (Windows) build failures.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,4 +1,5 @@
 srcdir := @abs_top_srcdir@
+relsrcdir := @top_srcdir@
 builddir := @abs_top_builddir@
 INSTALL_DIR := @prefix@
 
@@ -228,6 +229,7 @@ stamps/build-gcc-linux-stage1: $(srcdir)/riscv-gcc stamps/build-binutils-linux \
 		--disable-libgomp \
 		--disable-nls \
 		--disable-bootstrap \
+		--src=../$(relsrcdir)/riscv-gcc \
 		$(GCC_CHECKING_FLAGS) \
 		$(MULTILIB_FLAGS) \
 		$(WITH_ABI) \
@@ -256,6 +258,7 @@ stamps/build-gcc-linux-stage2: $(srcdir)/riscv-gcc $(addprefix stamps/build-glib
 		--disable-libquadmath \
 		--disable-nls \
 		--disable-bootstrap \
+		--src=../$(relsrcdir)/riscv-gcc \
 		$(GCC_CHECKING_FLAGS) \
 		$(MULTILIB_FLAGS) \
 		$(WITH_ABI) \
@@ -344,6 +347,7 @@ stamps/build-gcc-newlib-stage1: $(srcdir)/riscv-gcc stamps/build-binutils-newlib
 		--disable-libquadmath \
 		--disable-libgomp \
 		--disable-nls \
+		--src=../$(relsrcdir)/riscv-gcc \
 		$(GCC_CHECKING_FLAGS) \
 		$(MULTILIB_FLAGS) \
 		$(WITH_ABI) \
@@ -432,6 +436,7 @@ stamps/build-gcc-newlib-stage2: $(srcdir)/riscv-gcc stamps/build-newlib \
 		--disable-libquadmath \
 		--disable-libgomp \
 		--disable-nls \
+		--src=../$(relsrcdir)/riscv-gcc \
 		$(GCC_CHECKING_FLAGS) \
 		$(MULTILIB_FLAGS) \
 		$(WITH_ABI) \


### PR DESCRIPTION
	* Makefile.in (relsrcdir): New.
	(stamps/build-gcc-linux-stage1, stamps/build-gcc-linux-stage2)
	(stamps/build-gcc-newlib-stage1, stamps/build-gcc-newlib/stage2): Pass
	--src to configure set from relsrcdir.