### PR TITLE
Fix relsrcdir problem that breaks regression Makefile.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,7 +1,15 @@
 srcdir := @abs_top_srcdir@
-relsrcdir := @top_srcdir@
 builddir := @abs_top_builddir@
 INSTALL_DIR := @prefix@
+
+# We need a relative source dir for the gcc configure, to make msys2 mingw64
+# builds work.  Mayberelsrcdir is relative if a relative path was used to run
+# configure, otherwise absolute, so we have to check.
+mayberelsrcdir := @top_srcdir@
+gccsrcdir := $(shell case $(mayberelsrcdir) in \
+		  ([\\/]* | ?:[\\/]*)  echo $(mayberelsrcdir)/riscv-gcc ;; \
+		  (*)  echo ../$(mayberelsrcdir)/riscv-gcc ;; \
+		esac)
 
 PACKAGES :=
 
@@ -230,7 +238,7 @@ stamps/build-gcc-linux-stage1: $(srcdir)/riscv-gcc stamps/build-binutils-linux \
 		--disable-libgomp \
 		--disable-nls \
 		--disable-bootstrap \
-		--src=../$(relsrcdir)/riscv-gcc \
+		--src=$(gccsrcdir) \
 		$(GCC_CHECKING_FLAGS) \
 		$(MULTILIB_FLAGS) \
 		$(WITH_ABI) \
@@ -259,7 +267,7 @@ stamps/build-gcc-linux-stage2: $(srcdir)/riscv-gcc $(addprefix stamps/build-glib
 		--disable-libquadmath \
 		--disable-nls \
 		--disable-bootstrap \
-		--src=../$(relsrcdir)/riscv-gcc \
+		--src=$(gccsrcdir) \
 		$(GCC_CHECKING_FLAGS) \
 		$(MULTILIB_FLAGS) \
 		$(WITH_ABI) \
@@ -348,7 +356,7 @@ stamps/build-gcc-newlib-stage1: $(srcdir)/riscv-gcc stamps/build-binutils-newlib
 		--disable-libquadmath \
 		--disable-libgomp \
 		--disable-nls \
-		--src=../$(relsrcdir)/riscv-gcc \
+		--src=$(gccsrcdir) \
 		$(GCC_CHECKING_FLAGS) \
 		$(MULTILIB_FLAGS) \
 		$(WITH_ABI) \
@@ -437,7 +445,7 @@ stamps/build-gcc-newlib-stage2: $(srcdir)/riscv-gcc stamps/build-newlib \
 		--disable-libquadmath \
 		--disable-libgomp \
 		--disable-nls \
-		--src=../$(relsrcdir)/riscv-gcc \
+		--src=$(gccsrcdir) \
 		$(GCC_CHECKING_FLAGS) \
 		$(MULTILIB_FLAGS) \
 		$(WITH_ABI) \


### PR DESCRIPTION
Rename to mayberelsrcdir, and handle both cases where it can be relative
or absolute when setting gccsrcdir.