### PR TITLE
Force --with-expat to be enabled for gdb, since OpenOCD requires it.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -56,6 +56,8 @@ NEWLIB_TUPLE ?= $(call make_tuple,$(XLEN),elf)
 
 CFLAGS_FOR_TARGET := $(CFLAGS_FOR_TARGET_EXTRA) @cmodel@
 ASFLAGS_FOR_TARGET := $(ASFLAGS_FOR_TARGET_EXTRA) @cmodel@
+# --with-expat is required to enable XML support used by OpenOCD.
+BINUTILS_GDB_TARGET_FLAGS := --with-expat=yes $(BINUTILS_GDB_TARGET_FLAGS_EXTRA)
 GLIBC_TARGET_FLAGS := $(GLIBC_TARGET_FLAGS_EXTRA)
 GLIBC_CC_FOR_TARGET ?= $(LINUX_TUPLE)-gcc
 GLIBC_CXX_FOR_TARGET ?= $(LINUX_TUPLE)-g++
@@ -158,6 +160,7 @@ stamps/build-binutils-linux: $(srcdir)/riscv-binutils-gdb
 		@with_guile@ \
 		--disable-werror \
 		--disable-nls \
+		$(BINUTILS_GDB_TARGET_FLAGS) \
 		@enable_gdb@
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
@@ -289,6 +292,7 @@ stamps/build-binutils-linux-native: $(srcdir)/riscv-binutils-gdb stamps/build-gc
 		@with_guile@ \
 		--disable-werror \
 		--disable-nls \
+		$(BINUTILS_GDB_TARGET_FLAGS) \
 		@enable_gdb@
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
@@ -331,6 +335,7 @@ stamps/build-binutils-newlib: $(srcdir)/riscv-binutils-gdb
 		--prefix=$(INSTALL_DIR) \
 		@with_guile@ \
 		--disable-werror \
+		$(BINUTILS_GDB_TARGET_FLAGS) \
 		@enable_gdb@
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install

--- a/README.md
+++ b/README.md
@@ -26,15 +26,15 @@ Alternatively :
 Several standard packages are needed to build the toolchain.  On Ubuntu,
 executing the following command should suffice:
 
-    $ sudo apt-get install autoconf automake autotools-dev curl libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev
+    $ sudo apt-get install autoconf automake autotools-dev curl libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev
 
 On Fedora/CentOS/RHEL OS, executing the following command should suffice:
 
-    $ sudo yum install autoconf automake libmpc-devel mpfr-devel gmp-devel gawk  bison flex texinfo patchutils gcc gcc-c++ zlib-devel
+    $ sudo yum install autoconf automake libmpc-devel mpfr-devel gmp-devel gawk  bison flex texinfo patchutils gcc gcc-c++ zlib-devel expat-devel
 
 On OS X, you can use [Homebrew](http://brew.sh) to install the dependencies:
 
-    $ brew install gawk gnu-sed gmp mpfr libmpc isl zlib
+    $ brew install gawk gnu-sed gmp mpfr libmpc isl zlib expat
 
 To build the glibc (Linux) on OS X, you will need to build within a case-sensitive file
 system.  The simplest approach is to create and mount a new disk image with


### PR DESCRIPTION
Add BINUTILS_GDB_TARGET_FLAGS, init to --with-expat=yes, and pass to all 3 gdb configure commands.

I'm using a separate makefile variable here, patterned after GLIBC_TARGET_FLAGS, so that I can easily add the explanatory comment.  Since riscv-gnu-toolchain does not itself include OpenOCD, we could perhaps leave out the --with-expat=yes option and add that elsewhere using the new makefile variables, such as in the freedom-e-sdk Makefile, but that requires multiple patches, and might confuse people trying to build things separately, so I added it here.

This is for https://github.com/riscv/riscv-binutils-gdb/pull/127.

I verified that it builds, and is configured correctly, but have not reproduced the original problem, which apparently requires a build machine without libexpat installed.
