### PR TITLE
Make linux-native builds work again.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -58,6 +58,7 @@ CFLAGS_FOR_TARGET := $(CFLAGS_FOR_TARGET_EXTRA) @cmodel@
 ASFLAGS_FOR_TARGET := $(ASFLAGS_FOR_TARGET_EXTRA) @cmodel@
 # --with-expat is required to enable XML support used by OpenOCD.
 BINUTILS_GDB_TARGET_FLAGS := --with-expat=yes $(BINUTILS_GDB_TARGET_FLAGS_EXTRA)
+BINUTILS_GDB_NATIVE_FLAGS := $(BINUTILS_GDB_NATIVE_FLAGS_EXTRA)
 GLIBC_TARGET_FLAGS := $(GLIBC_TARGET_FLAGS_EXTRA)
 GLIBC_CC_FOR_TARGET ?= $(LINUX_TUPLE)-gcc
 GLIBC_CXX_FOR_TARGET ?= $(LINUX_TUPLE)-g++
@@ -293,7 +294,7 @@ stamps/build-binutils-linux-native: $(srcdir)/riscv-binutils-gdb stamps/build-gc
 		@with_guile@ \
 		--disable-werror \
 		--disable-nls \
-		$(BINUTILS_GDB_TARGET_FLAGS) \
+		$(BINUTILS_GDB_NATIVE_FLAGS) \
 		@enable_gdb@
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install


### PR DESCRIPTION
expat is required by cross for OpenOCD support, but not provided for native
builds, so replace BINUTILS_GDB_TARGET_FLAGS with BINUTILS_GDB_NATIVE_FLAGS.