### PR TITLE
Remove bashism from download_prerequisites check

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -138,7 +138,7 @@ $(addprefix src/,$(PACKAGES)): src/%: src/original-%
 	cp -a $< $@.tmp
 	$(srcdir)/scripts/cp_s $(srcdir)/$(notdir $@) $@.tmp
 	cd $@.tmp && patch -p1 < $(srcdir)/patches/$(notdir $@)
-	if test -f $@.tmp/contrib/download_prerequisites && test "@NEED_GCC_EXTERNAL_LIBRARIES@" == "true"; then cd $@.tmp && ./contrib/download_prerequisites; fi
+	if test -f $@.tmp/contrib/download_prerequisites && test "@NEED_GCC_EXTERNAL_LIBRARIES@" = "true"; then cd $@.tmp && ./contrib/download_prerequisites; fi
 	mv $@.tmp $@
 
 .PHONY: patches $(addprefix $(srcdir)/patches/,$(PACKAGES))


### PR DESCRIPTION
This change is to fix an error which prevents the Makefile
from downloading gmp, mpfr, mpc, and isl on systems with a
bourne shell.