### PR TITLE
Update GCC to the 8.1 release

### DIFF
--- a/test/gcc-linux/rv32imac-ilp32.log
+++ b/test/gcc-linux/rv32imac-ilp32.log
@@ -73,3 +73,55 @@ build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/iee
 build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/coarray_allocate_8.f08   -O1  execution test
 build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/coarray_ptr_comp_1.f08   -O1  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr81588.c scan-tree-dump-times reassoc1 "Optimizing range test [^\n\r]* and comparison" 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++11  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++14  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++98  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++11  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++14  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++98  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++11  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++14  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++98  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -Wc++-compat   scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -Wc++-compat   scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -Wc++-compat   scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c  (test for bogus messages, line 18)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c scan-tree-dump phiopt1 "MIN_EXPR"
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -Os  execution test
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat   (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84512.c scan-tree-dump optimized "return 285;"
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -Os  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -Os  execution test

--- a/test/gcc-linux/rv32imafdc-ilp32.log
+++ b/test/gcc-linux/rv32imafdc-ilp32.log
@@ -55,3 +55,55 @@ build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/iee
 build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/coarray_allocate_8.f08   -O1  execution test
 build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/coarray_ptr_comp_1.f08   -O1  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr81588.c scan-tree-dump-times reassoc1 "Optimizing range test [^\n\r]* and comparison" 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++11  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++14  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++98  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++11  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++14  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++98  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++11  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++14  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++98  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -Wc++-compat   scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -Wc++-compat   scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -Wc++-compat   scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c  (test for bogus messages, line 18)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c scan-tree-dump phiopt1 "MIN_EXPR"
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -Os  execution test
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat   (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84512.c scan-tree-dump optimized "return 285;"
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -Os  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -Os  execution test

--- a/test/gcc-linux/rv32imafdc-ilp32d.log
+++ b/test/gcc-linux/rv32imafdc-ilp32d.log
@@ -55,3 +55,55 @@ build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/iee
 build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/coarray_allocate_8.f08   -O1  execution test
 build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/coarray_ptr_comp_1.f08   -O1  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr81588.c scan-tree-dump-times reassoc1 "Optimizing range test [^\n\r]* and comparison" 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++11  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++14  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++98  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++11  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++14  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++98  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++11  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++14  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++98  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -Wc++-compat   scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -Wc++-compat   scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -Wc++-compat   scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c  (test for bogus messages, line 18)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c scan-tree-dump phiopt1 "MIN_EXPR"
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -Os  execution test
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat   (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84512.c scan-tree-dump optimized "return 285;"
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -Os  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -Os  execution test

--- a/test/gcc-linux/rv64imac-lp64.log
+++ b/test/gcc-linux/rv64imac-lp64.log
@@ -151,3 +151,55 @@ build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/coa
 build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/coarray_allocate_8.f08   -O1  execution test
 build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/coarray_ptr_comp_1.f08   -O1  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr81588.c scan-tree-dump-times reassoc1 "Optimizing range test [^\n\r]* and comparison" 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++11  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++14  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++98  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++11  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++14  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++98  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++11  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++14  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++98  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -Wc++-compat   scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -Wc++-compat   scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -Wc++-compat   scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c  (test for bogus messages, line 18)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c scan-tree-dump phiopt1 "MIN_EXPR"
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -Os  execution test
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat   (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84512.c scan-tree-dump optimized "return 285;"
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -Os  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -Os  execution test

--- a/test/gcc-linux/rv64imafdc-lp64.log
+++ b/test/gcc-linux/rv64imafdc-lp64.log
@@ -57,3 +57,55 @@ build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/atomic/c11-atomic-
 build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/coarray_allocate_8.f08   -O1  execution test
 build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/coarray_ptr_comp_1.f08   -O1  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr81588.c scan-tree-dump-times reassoc1 "Optimizing range test [^\n\r]* and comparison" 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++11  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++14  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++98  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++11  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++14  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++98  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++11  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++14  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++98  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -Wc++-compat   scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -Wc++-compat   scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -Wc++-compat   scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c  (test for bogus messages, line 18)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c scan-tree-dump phiopt1 "MIN_EXPR"
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -Os  execution test
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat   (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84512.c scan-tree-dump optimized "return 285;"
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -Os  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -Os  execution test

--- a/test/gcc-linux/rv64imafdc-lp64d.log
+++ b/test/gcc-linux/rv64imafdc-lp64d.log
@@ -63,3 +63,55 @@ build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/atomic/c11-atomic-
 build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/coarray_allocate_8.f08   -O1  execution test
 build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/coarray_ptr_comp_1.f08   -O1  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr81588.c scan-tree-dump-times reassoc1 "Optimizing range test [^\n\r]* and comparison" 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++11  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++14  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++98  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++11  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++14  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++98  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++11  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++14  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++98  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -Wc++-compat   scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -Wc++-compat   scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -Wc++-compat   scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c  (test for bogus messages, line 18)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c scan-tree-dump phiopt1 "MIN_EXPR"
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -Os  execution test
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat   (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84512.c scan-tree-dump optimized "return 285;"
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -Os  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -Os  execution test

--- a/test/gcc-newlib/rv32i-ilp32.log
+++ b/test/gcc-newlib/rv32i-ilp32.log
@@ -7,3 +7,55 @@ build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/ipa/iinline-cstag
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr42585.c scan-tree-dump-times optimized "struct _fat_ptr _T2" 0
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr42585.c scan-tree-dump-times optimized "struct _fat_ptr _ans" 0
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr81588.c scan-tree-dump-times reassoc1 "Optimizing range test [^\n\r]* and comparison" 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++11  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++14  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++98  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++11  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++14  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++98  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++11  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++14  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++98  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -Wc++-compat   scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -Wc++-compat   scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -Wc++-compat   scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c  (test for bogus messages, line 18)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c scan-tree-dump phiopt1 "MIN_EXPR"
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -Os  execution test
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat   (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84512.c scan-tree-dump optimized "return 285;"
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -Os  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -Os  execution test

--- a/test/gcc-newlib/rv32iac-ilp32.log
+++ b/test/gcc-newlib/rv32iac-ilp32.log
@@ -7,3 +7,55 @@ build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/ipa/iinline-cstag
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr42585.c scan-tree-dump-times optimized "struct _fat_ptr _T2" 0
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr42585.c scan-tree-dump-times optimized "struct _fat_ptr _ans" 0
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr81588.c scan-tree-dump-times reassoc1 "Optimizing range test [^\n\r]* and comparison" 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++11  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++14  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++98  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++11  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++14  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++98  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++11  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++14  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++98  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -Wc++-compat   scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -Wc++-compat   scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -Wc++-compat   scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c  (test for bogus messages, line 18)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c scan-tree-dump phiopt1 "MIN_EXPR"
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -Os  execution test
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat   (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84512.c scan-tree-dump optimized "return 285;"
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -Os  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -Os  execution test

--- a/test/gcc-newlib/rv32im-ilp32.log
+++ b/test/gcc-newlib/rv32im-ilp32.log
@@ -7,3 +7,55 @@ build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/ipa/iinline-cstag
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr42585.c scan-tree-dump-times optimized "struct _fat_ptr _T2" 0
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr42585.c scan-tree-dump-times optimized "struct _fat_ptr _ans" 0
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr81588.c scan-tree-dump-times reassoc1 "Optimizing range test [^\n\r]* and comparison" 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++11  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++14  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++98  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++11  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++14  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++98  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++11  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++14  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++98  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -Wc++-compat   scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -Wc++-compat   scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -Wc++-compat   scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c  (test for bogus messages, line 18)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c scan-tree-dump phiopt1 "MIN_EXPR"
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -Os  execution test
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat   (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84512.c scan-tree-dump optimized "return 285;"
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -Os  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -Os  execution test

--- a/test/gcc-newlib/rv32imac-ilp32.log
+++ b/test/gcc-newlib/rv32imac-ilp32.log
@@ -7,3 +7,55 @@ build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/ipa/iinline-cstag
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr42585.c scan-tree-dump-times optimized "struct _fat_ptr _T2" 0
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr42585.c scan-tree-dump-times optimized "struct _fat_ptr _ans" 0
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr81588.c scan-tree-dump-times reassoc1 "Optimizing range test [^\n\r]* and comparison" 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++11  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++14  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++98  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++11  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++14  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++98  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++11  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++14  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++98  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -Wc++-compat   scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -Wc++-compat   scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -Wc++-compat   scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c  (test for bogus messages, line 18)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c scan-tree-dump phiopt1 "MIN_EXPR"
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -Os  execution test
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat   (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84512.c scan-tree-dump optimized "return 285;"
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -Os  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -Os  execution test

--- a/test/gcc-newlib/rv32imafc-ilp32f.log
+++ b/test/gcc-newlib/rv32imafc-ilp32f.log
@@ -15,3 +15,55 @@ build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c   -O3 -g  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c   -Os  execution test
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++11  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++14  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++98  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++11  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++14  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++98  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++11  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++14  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++98  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -Wc++-compat   scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -Wc++-compat   scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -Wc++-compat   scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c  (test for bogus messages, line 18)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c scan-tree-dump phiopt1 "MIN_EXPR"
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -Os  execution test
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat   (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84512.c scan-tree-dump optimized "return 285;"
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -Os  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -Os  execution test

--- a/test/gcc-newlib/rv64imac-lp64.log
+++ b/test/gcc-newlib/rv64imac-lp64.log
@@ -7,3 +7,55 @@ build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/ipa/iinline-cstag
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr42585.c scan-tree-dump-times optimized "struct _fat_ptr _T2" 0
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr42585.c scan-tree-dump-times optimized "struct _fat_ptr _ans" 0
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr81588.c scan-tree-dump-times reassoc1 "Optimizing range test [^\n\r]* and comparison" 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++11  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++14  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++98  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++11  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++14  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++98  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++11  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++14  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++98  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -Wc++-compat   scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -Wc++-compat   scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -Wc++-compat   scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c  (test for bogus messages, line 18)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c scan-tree-dump phiopt1 "MIN_EXPR"
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -Os  execution test
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat   (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84512.c scan-tree-dump optimized "return 285;"
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -Os  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -Os  execution test

--- a/test/gcc-newlib/rv64imafdc-lp64d.log
+++ b/test/gcc-newlib/rv64imafdc-lp64d.log
@@ -15,3 +15,55 @@ build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c   -O3 -g  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c   -Os  execution test
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++11  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++14  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++98  scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++11  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++14  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++98  scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++11  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++14  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++98  scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -Wc++-compat   scan-assembler-times nop 2
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -Wc++-compat   scan-assembler-times nop 3
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -Wc++-compat   scan-assembler-times nop 1
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c  (test for bogus messages, line 18)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c scan-tree-dump phiopt1 "MIN_EXPR"
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -Os  execution test
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98  (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat   (test for warnings, line 76)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  memcpy (test for warnings, line 71)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 186)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 191)
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84512.c scan-tree-dump optimized "return 285;"
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -Os  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O0  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O1  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O3 -g  execution test
+build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -Os  execution test


### PR DESCRIPTION
This has no additional patches, but it does result in a whole host of
test suite failures.

@jim-wilson Do you have time to look at the failure list?  IIRC you did some analysis around the release, but I don't remember there being this many failures.  I just added every failure to every test list.