### PR TITLE
Upgrade host gcc version to fix travis testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,12 @@ addons:
       - libtool
       - patchutils
       - texinfo
-      - gcc-4.8
-      - g++-4.8
+      - gcc-6
+      - g++-6
 before_install:
   - export MAKEFLAGS="-j3"
-  - export CXX=g++-4.8
-  - export CC=gcc-4.8
+  - export CXX=g++-6
+  - export CC=gcc-6
 env:
 #  - CARGS="--enable-linux  --disable-multilib --with-arch=rv32imac --with-abi=ilp32"
 #  - CARGS="--enable-linux  --disable-multilib --with-arch=rv32imafdc --with-abi=ilp32"


### PR DESCRIPTION
The native x86 gcc-4.8 is miscompiling gcc-8, causing testsuite failures.  Upgrading to gcc-6 to fix this.

This is an experiment, since I've never looked at travis before, and I'm not sure if this will work, and don't know of any other way to test travis other than to submit a PR.
