### PR TITLE
Fix linux regressions

### DIFF
--- a/test/gcc-linux/rv32imac-ilp32.log
+++ b/test/gcc-linux/rv32imac-ilp32.log
@@ -65,7 +65,6 @@ build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/iee
 build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/rounding_1.f90   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  execution test
 build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/rounding_1.f90   -O3 -g  execution test
 build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/rounding_1.f90   -Os  execution test
-
 # These are regressions between GCC 7.1 and 7.2, but that might just be the
 # result of flakiness.  It appears that the gfortran coarray library overflows
 # the stack and depending on how the caller ends up allocating it may trigger
@@ -125,3 +124,151 @@ build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compa
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O3 -g  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -Os  execution test
+#
+# Check for nop insns fails due to ".option nopic".
+#
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -Wc++-compat   scan-assembler-times nop 2
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -Wc++-compat   scan-assembler-times nop 3
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -Wc++-compat   scan-assembler-times nop 1
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++11  scan-assembler-times nop 2
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++14  scan-assembler-times nop 2
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++98  scan-assembler-times nop 2
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++11  scan-assembler-times nop 3
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++14  scan-assembler-times nop 3
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++98  scan-assembler-times nop 3
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++11  scan-assembler-times nop 1
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++14  scan-assembler-times nop 1
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++98  scan-assembler-times nop 1
+#
+# Icache flush failures, due to missing gcc/glibc/qemu/etc patches after ABI
+# change.
+#
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/921215-1.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/931002-1.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-1.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-2.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/builtins-64.c (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/pr34457-1.c (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O0 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O1 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O3 -g -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -Os -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O0 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O1 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O3 -g -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -Os -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/trampoline-1.c (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/tailcall-7-run.c (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_dependency_4.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_4.f08   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/pointer_check_1.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/pointer_check_2.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/pointer_check_3.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/pointer_check_4.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/pointer_check_5.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_18.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_19.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_20.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_21.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_23.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_25.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_47.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_48.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_5.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_7.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_11.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_13.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_14.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_18.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_19.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_1.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_29.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_2.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_34.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_5.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_8.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_9.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_pass_3.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_result_7.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/unlimited_polymorphic_19.f90   -O0  (test for excess errors)
+#
+# Memcpy failures, possibly due to gcc-5.4 miscompilation of gcc-8.
+#
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_subroutine_3.f90   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_subroutine_3.f90   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_subroutine_3.f90   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_subroutine_3.f90   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_subroutine_3.f90   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c scan-tree-dump phiopt1 "MIN_EXPR"
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c  (test for bogus messages, line 18)
+#
+# Uncategorized fortran failure, maybe gcc-5.4 miscompilation related.
+#
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/matmul_15.f90   -O  execution test

--- a/test/gcc-linux/rv32imafdc-ilp32.log
+++ b/test/gcc-linux/rv32imafdc-ilp32.log
@@ -47,7 +47,6 @@ build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/iee
 build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/large_3.F90   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  execution test
 build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/large_3.F90   -O3 -g  execution test
 build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/large_3.F90   -Os  execution test
-
 # These are regressions between GCC 7.1 and 7.2, but that might just be the
 # result of flakiness.  It appears that the gfortran coarray library overflows
 # the stack and depending on how the caller ends up allocating it may trigger
@@ -107,3 +106,171 @@ build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compa
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O3 -g  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -Os  execution test
+#
+# Check for nop insns fails due to ".option nopic".
+#
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -Wc++-compat   scan-assembler-times nop 2
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -Wc++-compat   scan-assembler-times nop 3
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -Wc++-compat   scan-assembler-times nop 1
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++11  scan-assembler-times nop 2
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++14  scan-assembler-times nop 2
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++98  scan-assembler-times nop 2
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++11  scan-assembler-times nop 3
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++14  scan-assembler-times nop 3
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++98  scan-assembler-times nop 3
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++11  scan-assembler-times nop 1
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++14  scan-assembler-times nop 1
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++98  scan-assembler-times nop 1
+#
+# Icache flush failures, due to missing gcc/glibc/qemu/etc patches after ABI
+# change.
+#
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/921215-1.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/931002-1.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-1.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-2.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/builtins-64.c (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/pr34457-1.c (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O0 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O1 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O3 -g -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -Os -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O0 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O1 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O3 -g -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -Os -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/trampoline-1.c (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/tailcall-7-run.c (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_dependency_4.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/el#
+# Memcpy failures, possibly due to gcc-5.4 miscompilation of gcc-8.
+#
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c scan-tree-dump phiopt1 "MIN_EXPR"
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c  (test for bogus messages, line 18)
+emental_subroutine_3.f90   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_subroutine_3.f90   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_subroutine_3.f90   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_subroutine_3.f90   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_subroutine_3.f90   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_4.f08   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/pointer_check_1.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/pointer_check_2.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/pointer_check_3.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/pointer_check_4.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/pointer_check_5.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_18.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_19.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_20.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_21.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_23.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_25.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_47.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_48.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_5.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_7.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_11.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_13.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_14.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_18.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_19.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_1.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_29.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_2.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_34.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_5.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_8.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_9.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_pass_3.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_result_7.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/unlimited_polymorphic_19.f90   -O0  (test for excess errors)
+#
+# Problems with NaNs.
+#
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O0  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O1  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O3 -g  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -Os  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O0  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O1  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O3 -g  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -Os  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O0  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O1  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O3 -g  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -Os  execution test

--- a/test/gcc-linux/rv32imafdc-ilp32d.log
+++ b/test/gcc-linux/rv32imafdc-ilp32d.log
@@ -47,7 +47,6 @@ build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/iee
 build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/large_3.F90   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  execution test
 build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/large_3.F90   -O3 -g  execution test
 build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/large_3.F90   -Os  execution test
-
 # These are regressions between GCC 7.1 and 7.2, but that might just be the
 # result of flakiness.  It appears that the gfortran coarray library overflows
 # the stack and depending on how the caller ends up allocating it may trigger
@@ -107,3 +106,174 @@ build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compa
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O3 -g  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -Os  execution test
+#
+# Check for nop insns fails due to ".option nopic".
+#
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -Wc++-compat   scan-assembler-times nop 2
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -Wc++-compat   scan-assembler-times nop 3
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -Wc++-compat   scan-assembler-times nop 1
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++11  scan-assembler-times nop 2
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++14  scan-assembler-times nop 2
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++98  scan-assembler-times nop 2
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++11  scan-assembler-times nop 3
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++14  scan-assembler-times nop 3
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++98  scan-assembler-times nop 3
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++11  scan-assembler-times nop 1
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++14  scan-assembler-times nop 1
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++98  scan-assembler-times nop 1
+#
+# Icache flush failures, due to missing gcc/glibc/qemu/etc patches after ABI
+# change.
+#
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/921215-1.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/931002-1.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-1.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-2.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/builtins-64.c (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/pr34457-1.c (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O0 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O1 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O3 -g -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -Os -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O0 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O1 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O3 -g -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -Os -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/trampoline-1.c (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/tailcall-7-run.c (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_dependency_4.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_4.f08   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/pointer_check_1.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/pointer_check_2.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/pointer_check_3.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/pointer_check_4.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/pointer_check_5.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_18.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_19.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_20.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_21.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_23.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_25.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_47.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_48.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_5.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_7.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_11.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_13.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_14.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_18.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_19.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_1.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_29.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_2.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_34.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_5.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_8.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_9.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_pass_3.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_result_7.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/unlimited_polymorphic_19.f90   -O0  (test for excess errors)
+#
+# Memcpy failures, possibly due to gcc-5.4 miscompilation of gcc-8.
+#
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c scan-tree-dump phiopt1 "MIN_EXPR"
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c  (test for bogus messages, line 18)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/el
+emental_subroutine_3.f90   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_subroutine_3.f90   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_subroutine_3.f90   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_subroutine_3.f90   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_subroutine_3.f90   -Os  (test for excess errors)
+#
+# Problems with NaNs.
+#
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O0  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O1  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O3 -g  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -Os  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O0  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O1  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O3 -g  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -Os  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O0  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O1  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O3 -g  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -Os  execution test
+# Relocation truncated.
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/vec-cvt-1.c   -O0  (test for excess errors)

--- a/test/gcc-linux/rv64imac-lp64.log
+++ b/test/gcc-linux/rv64imac-lp64.log
@@ -143,7 +143,6 @@ build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/iee
 build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/coarray_allocate_8.f08   -O2  execution test
 build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/coarray_allocate_8.f08   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  execution test
 build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/coarray_allocate_8.f08   -O3 -g  execution test
-
 # These are regressions between GCC 7.1 and 7.2, but that might just be the
 # result of flakiness.  It appears that the gfortran coarray library overflows
 # the stack and depending on how the caller ends up allocating it may trigger
@@ -203,3 +202,176 @@ build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compa
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O3 -g  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -Os  execution test
+#
+# Check for nop insns fails due to ".option nopic".
+#
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -Wc++-compat   scan-assembler-times nop 2
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -Wc++-compat   scan-assembler-times nop 3
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -Wc++-compat   scan-assembler-times nop 1
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++11  scan-assembler-times nop 2
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++14  scan-assembler-times nop 2
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++98  scan-assembler-times nop 2
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++11  scan-assembler-times nop 3
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++14  scan-assembler-times nop 3
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++98  scan-assembler-times nop 3
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++11  scan-assembler-times nop 1
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++14  scan-assembler-times nop 1
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++98  scan-assembler-times nop 1
+#
+# Icache flush failures, due to missing gcc/glibc/qemu/etc patches after ABI
+# change.
+#
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/921215-1.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/931002-1.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-1.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-2.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/builtins-64.c (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/pr34457-1.c (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O0 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O1 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O3 -g -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -Os -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O0 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O1 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O3 -g -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -Os -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/trampoline-1.c (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/tailcall-7-run.c (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_dependency_4.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_4.f08   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/pointer_check_1.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/pointer_check_2.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/pointer_check_3.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/pointer_check_4.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/pointer_check_5.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_18.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_19.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_20.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_21.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_23.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_25.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_47.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_48.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_5.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_7.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_11.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_13.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_14.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_18.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_19.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_1.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_29.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_2.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_34.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_5.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_8.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_9.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_pass_3.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_result_7.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/unlimited_polymorphic_19.f90   -O0  (test for excess errors)
+#
+# Memcpy failures, possibly due to gcc-5.4 miscompilation of gcc-8.
+#
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  memcpy (test for warnings, line 71)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 186)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 191)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat   (test for warnings, line 76)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c scan-tree-dump phiopt1 "MIN_EXPR"
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c  (test for bogus messages, line 18)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_subroutine_3.f90   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_subroutine_3.f90   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_subroutine_3.f90   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_subroutine_3.f90   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_subroutine_3.f90   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 memcpy (test for warnings, line 71)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 186)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 191)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11  (test for warnings, line 76)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 memcpy (test for warnings, line 71)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 186)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 191)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14  (test for warnings, line 76)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 memcpy (test for warnings, line 71)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 186)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 191)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98  (test for warnings, line 76)
+#
+# Uncategorized fortran failure, maybe gcc-5.4 miscompilation related.
+#
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/matmul_15.f90   -O  execution test
+#
+# Uncategorized C++ failure.
+#
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: g++.dg/pr83239.C  -std=gnu++11  scan-tree-dump-not optimized "_ZNSt6vectorIiSaIiEE17_M_default_appendEm"
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: g++.dg/pr83239.C  -std=gnu++14  scan-tree-dump-not optimized "_ZNSt6vectorIiSaIiEE17_M_default_appendEm"
+#
+# Not gimple optimized, but is RTL optimized.
+#
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84512.c scan-tree-dump optimized "return 285;"

--- a/test/gcc-linux/rv64imafdc-lp64.log
+++ b/test/gcc-linux/rv64imafdc-lp64.log
@@ -49,7 +49,6 @@ build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/atomic/c11-atomic-
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/atomic/c11-atomic-exec-5.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  execution test
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/atomic/c11-atomic-exec-5.c   -O3 -g  execution test
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/atomic/c11-atomic-exec-5.c   -Os  execution test
-
 # These are regressions between GCC 7.1 and 7.2, but that might just be the
 # result of flakiness.  It appears that the gfortran coarray library overflows
 # the stack and depending on how the caller ends up allocating it may trigger
@@ -109,3 +108,196 @@ build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compa
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O3 -g  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -Os  execution test
+#
+# Check for nop insns fails due to ".option nopic".
+#
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -Wc++-compat   scan-assembler-times nop 2
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -Wc++-compat   scan-assembler-times nop 3
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -Wc++-compat   scan-assembler-times nop 1
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++11  scan-assembler-times nop 2
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++14  scan-assembler-times nop 2
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++98  scan-assembler-times nop 2
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++11  scan-assembler-times nop 3
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++14  scan-assembler-times nop 3
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++98  scan-assembler-times nop 3
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++11  scan-assembler-times nop 1
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++14  scan-assembler-times nop 1
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++98  scan-assembler-times nop 1
+#
+# Icache flush failures, due to missing gcc/glibc/qemu/etc patches after ABI
+# change.
+#
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/921215-1.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/931002-1.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-1.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-2.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/builtins-64.c (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/pr34457-1.c (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O0 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O1 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O3 -g -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -Os -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O0 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O1 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O3 -g -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -Os -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/trampoline-1.c (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/tailcall-7-run.c (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_dependency_4.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_4.f08   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/pointer_check_1.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/pointer_check_2.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/pointer_check_3.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/pointer_check_4.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/pointer_check_5.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_18.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_19.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_20.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_21.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_23.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_25.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_47.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_48.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_5.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_7.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_11.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_13.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_14.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_18.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_19.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_1.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_29.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_2.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_34.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_5.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_8.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_9.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_pass_3.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_result_7.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/unlimited_polymorphic_19.f90   -O0  (test for excess errors)
+#
+# Memcpy failures, possibly due to gcc-5.4 miscompilation of gcc-8.
+#
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  memcpy (test for warnings, line 71)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 186)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 191)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat   (test for warnings, line 76)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c scan-tree-dump phiopt1 "MIN_EXPR"
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c  (test for bogus messages, line 18)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_subroutine_3.f90   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_subroutine_3.f90   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_subroutine_3.f90   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_subroutine_3.f90   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_subroutine_3.f90   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 memcpy (test for warnings, line 71)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 186)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 191)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11  (test for warnings, line 76)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 memcpy (test for warnings, line 71)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 186)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 191)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14  (test for warnings, line 76)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 memcpy (test for warnings, line 71)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 186)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 191)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98  (test for warnings, line 76)
+#
+# Problems with NaNs.
+#
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O0  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O1  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O3 -g  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -Os  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O0  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O1  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O3 -g  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -Os  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O0  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O1  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O3 -g  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -Os  execution test
+#
+# Uncategorized C++ failure.
+#
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: g++.dg/pr83239.C  -std=gnu++11  scan-tree-dump-not optimized "_ZNSt6vectorIiSaIiEE17_M_default_appendEm"
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: g++.dg/pr83239.C  -std=gnu++14  scan-tree-dump-not optimized "_ZNSt6vectorIiSaIiEE17_M_default_appendEm"
+#
+# Not gimple optimized, but is RTL optimized.
+#
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84512.c scan-tree-dump optimized "return 285;"

--- a/test/gcc-linux/rv64imafdc-lp64d.log
+++ b/test/gcc-linux/rv64imafdc-lp64d.log
@@ -55,7 +55,6 @@ build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/atomic/c11-atomic-
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/atomic/c11-atomic-exec-5.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  execution test
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/atomic/c11-atomic-exec-5.c   -O3 -g  execution test
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/atomic/c11-atomic-exec-5.c   -Os  execution test
-
 # These are regressions between GCC 7.1 and 7.2, but that might just be the
 # result of flakiness.  It appears that the gfortran coarray library overflows
 # the stack and depending on how the caller ends up allocating it may trigger
@@ -115,3 +114,196 @@ build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compa
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O3 -g  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -Os  execution test
+#
+# Check for nop insns fails due to ".option nopic".
+#
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -Wc++-compat   scan-assembler-times nop 2
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -Wc++-compat   scan-assembler-times nop 3
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -Wc++-compat   scan-assembler-times nop 1
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++11  scan-assembler-times nop 2
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++14  scan-assembler-times nop 2
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++98  scan-assembler-times nop 2
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++11  scan-assembler-times nop 3
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++14  scan-assembler-times nop 3
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-default.c  -std=gnu++98  scan-assembler-times nop 3
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++11  scan-assembler-times nop 1
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++14  scan-assembler-times nop 1
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-definition.c  -std=gnu++98  scan-assembler-times nop 1
+#
+# Icache flush failures, due to missing gcc/glibc/qemu/etc patches after ABI
+# change.
+#
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/20000822-1.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/921215-1.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/931002-1.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-1.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-2.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-3.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-5.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.c-torture/execute/nestfunc-6.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/builtins-64.c (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/pr34457-1.c (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O0 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O1 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O3 -g -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -Os -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-5.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O0 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O1 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2 -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O3 -g -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -Os -fpic (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/stackalign/nested-6.c   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/trampoline-1.c (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/tailcall-7-run.c (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_dependency_4.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_2.f08   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_3.f08   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/internal_dummy_4.f08   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/pointer_check_1.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/pointer_check_2.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/pointer_check_3.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/pointer_check_4.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/pointer_check_5.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_18.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_19.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_20.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_21.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_23.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_25.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_47.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_48.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_5.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_7.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_11.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_13.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_14.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_18.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_19.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_1.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_29.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_2.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_34.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_5.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_8.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_9.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_comp_pass_3.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/proc_ptr_result_7.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -O0  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/structure_constructor_11.f90   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/unlimited_polymorphic_19.f90   -O0  (test for excess errors)
+#
+# Memcpy failures, possibly due to gcc-5.4 miscompilation of gcc-8.
+#
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  memcpy (test for warnings, line 71)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 186)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat  strncpy (test for warnings, line 191)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: c-c++-common/Warray-bounds-2.c  -Wc++-compat   (test for warnings, line 76)
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c scan-tree-dump phiopt1 "MIN_EXPR"
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c  (test for bogus messages, line 18)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_subroutine_3.f90   -O1  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_subroutine_3.f90   -O2  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_subroutine_3.f90   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_subroutine_3.f90   -O3 -g  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/elemental_subroutine_3.f90   -Os  (test for excess errors)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 memcpy (test for warnings, line 71)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 186)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11 strncpy (test for warnings, line 191)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++11  (test for warnings, line 76)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 memcpy (test for warnings, line 71)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 186)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14 strncpy (test for warnings, line 191)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++14  (test for warnings, line 76)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 memcpy (test for warnings, line 71)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 186)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98 strncpy (test for warnings, line 191)
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/Warray-bounds-2.c  -std=gnu++98  (test for warnings, line 76)
+#
+# Problems with NaNs.
+#
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O0  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O1  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -O3 -g  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-5.c   -Os  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O0  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O1  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O3 -g  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -Os  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O0  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O1  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O3 -g  execution test
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -Os  execution test
+#
+# Uncategorized C++ failure.
+#
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: g++.dg/pr83239.C  -std=gnu++11  scan-tree-dump-not optimized "_ZNSt6vectorIiSaIiEE17_M_default_appendEm"
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: g++.dg/pr83239.C  -std=gnu++14  scan-tree-dump-not optimized "_ZNSt6vectorIiSaIiEE17_M_default_appendEm"
+#
+# Not gimple optimized, but is RTL optimized.
+#
+build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84512.c scan-tree-dump optimized "return 285;"


### PR DESCRIPTION
A blank line in a log file matches nothing, when combined with grep -v it
matches everything, which means we have had no linux regression testing
since this mistake was made Sept 2017.  Delete the blank lines, and add
current failures to the list with explanations, so we can re-enable regression
testing, and prevent the problem from getting worse.
