### PR TITLE
Fail if report log file has an empty line.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -633,17 +633,23 @@ stamps/check-gdb-linux: stamps/build-gcc-linux-stage2 stamps/build-gdb-linux sta
 .PHONY: report-gcc-newlib report-gcc-newlib-nano
 report-gcc-newlib: stamps/check-gcc-newlib
 	stat $(patsubst %,$(srcdir)/test/gcc-newlib/%.log,$(NEWLIB_MULTILIB_NAMES)) || exit 1
+# Fail if there are blank lines in the log file used as input for grep below.
+	if grep '^$$' $(patsubst %,$(srcdir)/test/gcc-newlib/%.log,$(NEWLIB_MULTILIB_NAMES)); then exit 1; fi
 	if find build-gcc-newlib-stage2/gcc/testsuite/ -iname '*.sum' | xargs grep ^FAIL | sort | grep -F -v $(patsubst %,--file=$(srcdir)/test/gcc-newlib/%.log,$(NEWLIB_MULTILIB_NAMES)); then false; else true; fi
 	if test "$$(find build-gcc-newlib-stage2/gcc/testsuite/ -iname '*.sum' | xargs cat | wc -l)" -lt 100; then false; else true; fi
 
 report-gcc-newlib-nano: stamps/check-gcc-newlib-nano
 	stat $(patsubst %,$(srcdir)/test/gcc-newlib/%.log,$(NEWLIB_MULTILIB_NAMES)) || exit 1
+# Fail if there are blank lines in the log file used as input for grep below.
+	if grep '^$$' $(patsubst %,$(srcdir)/test/gcc-newlib/%.log,$(NEWLIB_MULTILIB_NAMES)); then exit 1; fi
 	if find build-gcc-newlib-stage2/gcc/testsuite/ -iname '*.sum' | xargs grep ^FAIL | sort | grep -F -v $(patsubst %,--file=$(srcdir)/test/gcc-newlib/%.log,$(NEWLIB_MULTILIB_NAMES)); then false; else true; fi
 	if test "$$(find build-gcc-newlib-stage2/gcc/testsuite/ -iname '*.sum' | xargs cat | wc -l)" -lt 100; then false; else true; fi
 
 .PHONY: report-gcc-linux
 report-gcc-linux: stamps/check-gcc-linux
 	stat $(patsubst %,$(srcdir)/test/gcc-linux/%.log,$(GLIBC_MULTILIB_NAMES)) || exit 1
+# Fail if there are blank lines in the log file used as input for grep below.
+	if grep '^$$' $(patsubst %,$(srcdir)/test/gcc-linux/%.log,$(GLIBC_MULTILIB_NAMES)); then exit 1; fi
 	if find build-gcc-linux-stage2/gcc/testsuite/ -iname '*.sum' | xargs grep ^FAIL | sort | grep -F -v $(patsubst %,--file=$(srcdir)/test/gcc-linux/%.log,$(GLIBC_MULTILIB_NAMES)); then false; else true; fi
 	if test "$$(find build-gcc-linux-stage2/gcc/testsuite/ -iname '*.sum' | xargs cat | wc -l)" -lt 100; then false; else true; fi
 
@@ -660,15 +666,21 @@ report-dhrystone-linux: $(patsubst %,stamps/check-dhrystone-linux-%,$(GLIBC_MULT
 .PHONY: report-binutils-newlib report-binutils-newlib-nano
 report-binutils-newlib: stamps/check-binutils-newlib
 	stat $(patsubst %,$(srcdir)/test/binutils-newlib/%.log,$(NEWLIB_MULTILIB_NAMES)) || exit 1
+# Fail if there are blank lines in the log file used as input for grep below.
+	if grep '^$$' $(patsubst %,$(srcdir)/test/binutils-newlib/%.log,$(NEWLIB_MULTILIB_NAMES)); then exit 1; fi
 	if find build-binutils-newlib -iname '*.sum' | xargs grep ^FAIL | sort | grep -F -v $(patsubst %,--file=$(srcdir)/test/binutils-newlib/%.log,$(NEWLIB_MULTILIB_NAMES)); then false; else true; fi
 
 report-binutils-newlib-nano: stamps/check-binutils-newlib-nano
 	stat $(patsubst %,$(srcdir)/test/binutils-newlib/%.log,$(NEWLIB_MULTILIB_NAMES)) || exit 1
+# Fail if there are blank lines in the log file used as input for grep below.
+	if grep '^$$' $(patsubst %,$(srcdir)/test/binutils-newlib/%.log,$(NEWLIB_MULTILIB_NAMES)); then exit 1; fi
 	if find build-binutils-newlib -iname '*.sum' | xargs grep ^FAIL | sort | grep -F -v $(patsubst %,--file=$(srcdir)/test/binutils-newlib/%.log,$(NEWLIB_MULTILIB_NAMES)); then false; else true; fi
 
 .PHONY: report-binutils-linux
 report-binutils-linux: stamps/check-binutils-linux
 	stat $(patsubst %,$(srcdir)/test/binutils-linux/%.log,$(GLIBC_MULTILIB_NAMES)) || exit 1
+# Fail if there are blank lines in the log file used as input for grep below.
+	if grep '^$$' $(patsubst %,$(srcdir)/test/binutils-linux/%.log,$(GLIBC_MULTILIB_NAMES)); then exit 1; fi
 	if find build-binutils-linux -iname '*.sum' | xargs grep ^FAIL | sort | grep -F -v $(patsubst %,--file=$(srcdir)/test/binutils-linux/%.log,$(GLIBC_MULTILIB_NAMES)); then false; else true; fi
 
 clean:
@@ -677,15 +689,21 @@ clean:
 .PHONY: report-gdb-newlib report-gdb-newlib-nano
 report-gdb-newlib: stamps/check-gdb-newlib
 	stat $(patsubst %,$(srcdir)/test/gdb-newlib/%.log,$(NEWLIB_MULTILIB_NAMES)) || exit 1
+# Fail if there are blank lines in the log file used as input for grep below.
+	if grep '^$$' $(patsubst %,$(srcdir)/test/gdb-newlib/%.log,$(NEWLIB_MULTILIB_NAMES)); then exit 1; fi
 	if find build-gdb-newlib -iname '*.sum' | xargs grep ^FAIL | sort | grep -F -v $(patsubst %,--file=$(srcdir)/test/gdb-newlib/%.log,$(NEWLIB_MULTILIB_NAMES)); then false; else true; fi
 
 report-gdb-newlib-nano: stamps/check-gdb-newlib-nano
 	stat $(patsubst %,$(srcdir)/test/gdb-newlib/%.log,$(NEWLIB_MULTILIB_NAMES)) || exit 1
+# Fail if there are blank lines in the log file used as input for grep below.
+	if grep '^$$' $(patsubst %,$(srcdir)/test/gdb-newlib/%.log,$(NEWLIB_MULTILIB_NAMES)); then exit 1; fi
 	if find build-gdb-newlib -iname '*.sum' | xargs grep ^FAIL | sort | grep -F -v $(patsubst %,--file=$(srcdir)/test/gdb-newlib/%.log,$(NEWLIB_MULTILIB_NAMES)); then false; else true; fi
 
 .PHONY: report-gdb-linux
 report-gdb-linux: stamps/check-gdb-linux
 	stat $(patsubst %,$(srcdir)/test/gdb-linux/%.log,$(GLIBC_MULTILIB_NAMES)) || exit 1
+# Fail if there are blank lines in the log file used as input for grep below.
+	if grep '^$$' $(patsubst %,$(srcdir)/test/gdb-linux/%.log,$(GLIBC_MULTILIB_NAMES)); then exit 1; fi
 	if find build-gdb-linux -iname '*.sum' | xargs grep ^FAIL | sort | grep -F -v $(patsubst %,--file=$(srcdir)/test/gdb-linux/%.log,$(GLIBC_MULTILIB_NAMES)); then false; else true; fi
 
 distclean: clean


### PR DESCRIPTION
Use of grep -v means that an empty line matches everything, and hence make
report can never fail, so we need to check for this case and force failure.
