### PR TITLE
Define CXX for glibc builds.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -237,6 +237,7 @@ endif
 	mkdir $(notdir $@)
 	cd $(notdir $@) && \
 		CC="$(GLIBC_CC_FOR_TARGET) $($@_CFLAGS)" \
+		CXX="$(GLIBC_CXX_FOR_TARGET) $($@_CFLAGS)" \
 		CFLAGS="$(CFLAGS_FOR_TARGET) -g -O2 $($@_CFLAGS)" \
 		CXXFLAGS="$(CXXFLAGS_FOR_TARGET) -g -O2 $($@_CFLAGS)" \
 		ASFLAGS="$(ASFLAGS_FOR_TARGET) $($@_CFLAGS)" \


### PR DESCRIPTION
FSF glibc now has a C++ file, so this is needed to make builds work with
upstream glibc.
