### PR TITLE
Remove --disable-atomic option, which stopped working about 2 years ago.

### DIFF
--- a/configure
+++ b/configure
@@ -656,7 +656,6 @@ ac_subst_files=''
 ac_user_opts='
 enable_option_checking
 enable_linux
-enable_atomic
 with_arch
 with_abi
 enable_multilib
@@ -1297,8 +1296,6 @@ Optional Features:
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
   --enable-linux          set linux as the default make target
                           [--disable-linux]
-  --disable-atomic        disable use of atomic memory instructions in glibc
-                          [--enable-atomic]
   --enable-multilib       build both RV32 and RV64 runtime libraries
                           [--disable-multilib]
   --enable-gcc-checking   Enable gcc internal checking, it will make gcc very
@@ -3230,15 +3227,6 @@ else
   default_target=newlib
 
 fi
-
-# Check whether --enable-atomic was given.
-if test "${enable_atomic+set}" = set; then :
-  enableval=$enable_atomic;
-else
-  enable_atomic=yes
-
-fi
-
 
 
 # Check whether --with-arch was given.

--- a/configure.ac
+++ b/configure.ac
@@ -50,13 +50,6 @@ AS_IF([test "x$enable_linux" != xno],
 	[AC_SUBST(default_target, linux)],
 	[AC_SUBST(default_target, newlib)])
 
-AC_ARG_ENABLE(atomic,
-	[AS_HELP_STRING([--disable-atomic],
-		[disable use of atomic memory instructions in glibc @<:@--enable-atomic@:>@])],
-	[],
-	[enable_atomic=yes]
-	)
-
 AC_ARG_WITH(arch,
 	[AS_HELP_STRING([--with-arch=rv64imafdc],
 		[Sets the base RISC-V ISA, defaults to rv64imafdc])],


### PR DESCRIPTION
Looking at git history, this stopped doing anything useful about 2 years ago, which is long before I started doing RISC-V work.  I don't know the history here, but this is clearly not useful anymore and should be removed.
