### PR TITLE
Add enable-newlib-io-long-double enable-newlib-io-float options

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -44,6 +44,8 @@ MULTILIB_FLAGS := @multilib_flags@
 NEWLIB_MULTILIB_NAMES := @newlib_multilib_names@
 GLIBC_MULTILIB_NAMES := @glibc_multilib_names@
 GCC_CHECKING_FLAGS := @gcc_checking@
+NEWLIB_IO_FLOAT_FLAG := @newlib_io_float@
+NEWLIB_IO_LONG_DOUBLE_FLAG := @newlib_io_long_double@
 
 XLEN := $(shell echo $(WITH_ARCH) | tr A-Z a-z | sed 's/.*rv\([0-9]*\).*/\1/')
 ifneq ($(XLEN),32)
@@ -468,7 +470,8 @@ stamps/build-newlib: $(srcdir)/riscv-newlib stamps/build-gcc-newlib-stage1
 		--target=$(NEWLIB_TUPLE) \
 		$(CONFIGURE_HOST) \
 		--prefix=$(INSTALL_DIR) \
-		--enable-newlib-io-long-double \
+		$(NEWLIB_IO_FLOAT_FLAG) \
+		$(NEWLIB_IO_LONG_DOUBLE_FLAG) \
 		--enable-newlib-io-long-long \
 		--enable-newlib-io-c99-formats \
 		CFLAGS_FOR_TARGET="-Os $(CFLAGS_FOR_TARGET)" \

--- a/configure.ac
+++ b/configure.ac
@@ -166,4 +166,20 @@ AS_IF([test "x$enable_gdb" != xno],
 	[AC_SUBST(enable_gdb, --enable-gdb)],
 	[AC_SUBST(enable_gdb, --disable-gdb)])
 
+AC_ARG_ENABLE([newlib-io-float],
+    AS_HELP_STRING([--enable-newlib-io-float], [enable float type support in IO functions printf/scanf]))
+
+AS_IF([test "x$enable_newlib_io_float" = "xyes"], 
+	[AC_SUBST(newlib_io_float, --enable-newlib-io-float=yes)]
+)
+
+AC_ARG_ENABLE(newlib-io-long-double,
+    [AS_HELP_STRING([--disable-newlib-io-long-double], [disable long double type support in IO functions printf/scanf])],
+    [],
+    [enable_newlib_io_long_double=yes]	
+)
+AS_IF([test "x$enable_newlib_io_long_double" != "xno"],
+	[AC_SUBST(newlib_io_long_double, --enable-newlib-io-long-double=yes)],
+	[AC_SUBST(newlib_io_long_double, --enable-newlib-io-long-double=no)]
+)
 AC_OUTPUT


### PR DESCRIPTION
RISCV toolchain config files are modified to add option to newlib that allows the floating-point printf support to be split into two functions: one for long-double, and one for float.