### PR TITLE
Allow building a 32bit musl toolchain

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -627,7 +627,7 @@ stamps/build-musl-linux-headers: $(srcdir)/riscv-musl stamps/build-gcc-musl-stag
 	$(MAKE) -C $(notdir $@) install-headers
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-musl-linux-riscv64: $(srcdir)/riscv-musl stamps/build-gcc-musl-stage1
+stamps/build-musl-linux: $(srcdir)/riscv-musl stamps/build-gcc-musl-stage1
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	cd $(notdir $@) && \
@@ -637,18 +637,16 @@ stamps/build-musl-linux-riscv64: $(srcdir)/riscv-musl stamps/build-gcc-musl-stag
 		CXXFLAGS="$(CXXFLAGS_FOR_TARGET) -g -O2 $($@_CFLAGS)" \
 		ASFLAGS="$(ASFLAGS_FOR_TARGET) $($@_CFLAGS)" \
 		$</configure \
-		--host=riscv64-unknown-linux-musl \
-		--prefix=$(SYSROOT)/usr \
+		--host=$(MUSL_TUPLE) \
+		--prefix=$(SYSROOT) \
 		--disable-werror \
 		--enable-shared \
-		--with-headers=$(srcdir)/linux-headers/include \
-		--enable-kernel=3.0.0 \
 		$(MUSL_TARGET_FLAGS)
 	$(MAKE) -C $(notdir $@)
-	+flock $(SYSROOT)/.lock $(MAKE) -C $(notdir $@) install install_root=$(SYSROOT)
+	+flock $(SYSROOT)/.lock $(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-gcc-musl-stage2: $(srcdir)/riscv-gcc stamps/build-musl-linux-riscv64 \
+stamps/build-gcc-musl-stage2: $(srcdir)/riscv-gcc stamps/build-musl-linux \
                                stamps/build-musl-linux-headers
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)


### PR DESCRIPTION
Note that musl doesn't support multilib. I tested this --with-arch=rv32gc.