### PR TITLE
Fix typo, change --disable-libreadline to --disable-readline.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -193,7 +193,7 @@ stamps/build-binutils-linux: $(srcdir)/riscv-binutils
 		--disable-gdb \
 		--disable-sim \
 		--disable-libdecnumber \
-		--disable-libreadline
+		--disable-readline
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
@@ -353,7 +353,7 @@ stamps/build-binutils-linux-native: $(srcdir)/riscv-binutils stamps/build-gcc-li
 		--disable-gdb \
 		--disable-sim \
 		--disable-libdecnumber \
-		--disable-libreadline
+		--disable-readline
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
@@ -404,7 +404,7 @@ stamps/build-binutils-newlib: $(srcdir)/riscv-binutils
 		--disable-gdb \
 		--disable-sim \
 		--disable-libdecnumber \
-		--disable-libreadline
+		--disable-readline
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
@@ -574,7 +574,7 @@ stamps/build-binutils-musl: $(srcdir)/riscv-binutils
 		--disable-gdb \
 		--disable-sim \
 		--disable-libdecnumber \
-		--disable-libreadline
+		--disable-readline
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@


### PR DESCRIPTION
Prevents building useless library for binutils builds.
