### PR TITLE
Add configure option --enable-newlib-formatted-io

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -44,6 +44,7 @@ MULTILIB_FLAGS := @multilib_flags@
 NEWLIB_MULTILIB_NAMES := @newlib_multilib_names@
 GLIBC_MULTILIB_NAMES := @glibc_multilib_names@
 GCC_CHECKING_FLAGS := @gcc_checking@
+NEWLIB_FORMATTED_IO_FLAG := @newlib_formatted_io@
 
 XLEN := $(shell echo $(WITH_ARCH) | tr A-Z a-z | sed 's/.*rv\([0-9]*\).*/\1/')
 ifneq ($(XLEN),32)
@@ -468,6 +469,7 @@ stamps/build-newlib: $(srcdir)/riscv-newlib stamps/build-gcc-newlib-stage1
 		--target=$(NEWLIB_TUPLE) \
 		$(CONFIGURE_HOST) \
 		--prefix=$(INSTALL_DIR) \
+		$(NEWLIB_FORMATTED_IO_FLAG) \
 		--enable-newlib-io-long-double \
 		--enable-newlib-io-long-long \
 		--enable-newlib-io-c99-formats \

--- a/configure.ac
+++ b/configure.ac
@@ -166,4 +166,10 @@ AS_IF([test "x$enable_gdb" != xno],
 	[AC_SUBST(enable_gdb, --enable-gdb)],
 	[AC_SUBST(enable_gdb, --disable-gdb)])
 
+AC_ARG_ENABLE([newlib-formatted-io],
+    AS_HELP_STRING([--enable-newlib-formatted-io], [enable formatted IO functions]))
+
+AS_IF([test "x$enable_newlib_formatted_io" = "xyes"], 
+	[AC_SUBST(newlib_formatted_io, --enable-newlib-formatted-io=yes)]
+)
 AC_OUTPUT


### PR DESCRIPTION
This is related to: https://github.com/riscv/riscv-gnu-toolchain/pull/389#issuecomment-436435356
Top level configure option --enable-newlib-formatted-io  is added which moves printf long double support to separate function.
