### PR TITLE
Upgrade to gcc-8.3.0 release.

### DIFF
--- a/test/gcc-linux/rv32imac-ilp32.log
+++ b/test/gcc-linux/rv32imac-ilp32.log
@@ -272,3 +272,7 @@ build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84859.c
 # Uncategorized fortran failure, maybe gcc-5.4 miscompilation related.
 #
 build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/matmul_15.f90   -O  execution test
+#
+# Upstream regression, PR 86153.
+#
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: g++.dg/pr83239.C  -std=gnu++98 (test for excess errors)

--- a/test/gcc-linux/rv32imafdc-ilp32.log
+++ b/test/gcc-linux/rv32imafdc-ilp32.log
@@ -274,3 +274,16 @@ build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c 
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -O3 -g  execution test
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -Os  execution test
+#
+# Upstream regression, PR 86153.
+#
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: g++.dg/pr83239.C  -std=gnu++98 (test for excess errors)
+#
+# Possible bug in our old glibc.
+#
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/ieee_6.f90   -O0  execution test
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/ieee_6.f90   -O1  execution test
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/ieee_6.f90   -O2  execution test
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/ieee_6.f90   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  execution test
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/ieee_6.f90   -O3 -g  execution test
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/ieee_6.f90   -Os  execution test

--- a/test/gcc-linux/rv32imafdc-ilp32d.log
+++ b/test/gcc-linux/rv32imafdc-ilp32d.log
@@ -277,3 +277,16 @@ build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c 
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr52451.c   -Os  execution test
 # Relocation truncated.
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/vec-cvt-1.c   -O0  (test for excess errors)
+#
+# Upstream regression, PR 86153.
+#
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: g++.dg/pr83239.C  -std=gnu++98 (test for excess errors)
+#
+# Possible bug in our old glibc.
+#
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/ieee_6.f90   -O0  execution test
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/ieee_6.f90   -O1  execution test
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/ieee_6.f90   -O2  execution test
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/ieee_6.f90   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  execution test
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/ieee_6.f90   -O3 -g  execution test
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/ieee_6.f90   -Os  execution test

--- a/test/gcc-linux/rv64imac-lp64.log
+++ b/test/gcc-linux/rv64imac-lp64.log
@@ -375,3 +375,7 @@ build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: g++.dg/pr83239.C  -std=gn
 # Not gimple optimized, but is RTL optimized.
 #
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84512.c scan-tree-dump optimized "return 285;"
+#
+# Upstream regression, PR 86153.
+#
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: g++.dg/pr83239.C  -std=gnu++98 (test for excess errors)

--- a/test/gcc-linux/rv64imafdc-lp64.log
+++ b/test/gcc-linux/rv64imafdc-lp64.log
@@ -301,3 +301,16 @@ build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: g++.dg/pr83239.C  -std=gn
 # Not gimple optimized, but is RTL optimized.
 #
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84512.c scan-tree-dump optimized "return 285;"
+#
+# Upstream regression, PR 86153.
+#
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: g++.dg/pr83239.C  -std=gnu++98 (test for excess errors)
+#
+# Possible bug in our old glibc.
+#
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/ieee_6.f90   -O0  execution test
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/ieee_6.f90   -O1  execution test
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/ieee_6.f90   -O2  execution test
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/ieee_6.f90   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  execution test
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/ieee_6.f90   -O3 -g  execution test
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/ieee_6.f90   -Os  execution test

--- a/test/gcc-linux/rv64imafdc-lp64d.log
+++ b/test/gcc-linux/rv64imafdc-lp64d.log
@@ -307,3 +307,16 @@ build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: g++.dg/pr83239.C  -std=gn
 # Not gimple optimized, but is RTL optimized.
 #
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr84512.c scan-tree-dump optimized "return 285;"
+#
+# Upstream regression, PR 86153.
+#
+build-gcc-linux-stage2/gcc/testsuite/g++/g++.sum:FAIL: g++.dg/pr83239.C  -std=gnu++98 (test for excess errors)
+#
+# Possible bug in our old glibc.
+#
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/ieee_6.f90   -O0  execution test
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/ieee_6.f90   -O1  execution test
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/ieee_6.f90   -O2  execution test
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/ieee_6.f90   -O3 -fomit-frame-pointer -funroll-loops -fpeel-loops -ftracer -finline-functions  execution test
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/ieee_6.f90   -O3 -g  execution test
+build-gcc-linux-stage2/gcc/testsuite/gfortran/gfortran.sum:FAIL: gfortran.dg/ieee/ieee_6.f90   -Os  execution test

--- a/test/gcc-newlib/rv32i-ilp32.log
+++ b/test/gcc-newlib/rv32i-ilp32.log
@@ -59,3 +59,7 @@ build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compa
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O3 -g  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -Os  execution test
+#
+# Upstream regression, PR 86153.
+#
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: g++.dg/pr83239.C  -std=gnu++98 (test for excess errors)

--- a/test/gcc-newlib/rv32iac-ilp32.log
+++ b/test/gcc-newlib/rv32iac-ilp32.log
@@ -59,3 +59,7 @@ build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compa
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O3 -g  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -Os  execution test
+#
+# Upstream regression, PR 86153.
+#
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: g++.dg/pr83239.C  -std=gnu++98 (test for excess errors)

--- a/test/gcc-newlib/rv32im-ilp32.log
+++ b/test/gcc-newlib/rv32im-ilp32.log
@@ -59,3 +59,7 @@ build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compa
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O3 -g  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -Os  execution test
+#
+# Upstream regression, PR 86153.
+#
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: g++.dg/pr83239.C  -std=gnu++98 (test for excess errors)

--- a/test/gcc-newlib/rv32imac-ilp32.log
+++ b/test/gcc-newlib/rv32imac-ilp32.log
@@ -59,3 +59,7 @@ build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compa
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O3 -g  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -Os  execution test
+#
+# Upstream regression, PR 86153.
+#
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: g++.dg/pr83239.C  -std=gnu++98 (test for excess errors)

--- a/test/gcc-newlib/rv32imafc-ilp32f.log
+++ b/test/gcc-newlib/rv32imafc-ilp32f.log
@@ -67,3 +67,7 @@ build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compa
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -O3 -g  execution test
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -Os  execution test
+#
+# Upstream regression, PR 86153.
+#
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: g++.dg/pr83239.C  -std=gnu++98 (test for excess errors)

--- a/test/gcc-newlib/rv64imac-lp64.log
+++ b/test/gcc-newlib/rv64imac-lp64.log
@@ -62,3 +62,7 @@ build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compa
 # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86153
 build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: g++.dg/pr83239.C  -std=gnu++11  scan-tree-dump-not optimized "_ZNSt6vectorIiSaIiEE17_M_default_appendEm"
 build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: g++.dg/pr83239.C  -std=gnu++14  scan-tree-dump-not optimized "_ZNSt6vectorIiSaIiEE17_M_default_appendEm"
+#
+# Upstream regression, PR 86153.
+#
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: g++.dg/pr83239.C  -std=gnu++98 (test for excess errors)

--- a/test/gcc-newlib/rv64imafdc-lp64d.log
+++ b/test/gcc-newlib/rv64imafdc-lp64d.log
@@ -69,3 +69,7 @@ build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compa
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/inf-compare-6.c   -Os  execution test
 build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: g++.dg/pr83239.C  -std=gnu++11  scan-tree-dump-not optimized "_ZNSt6vectorIiSaIiEE17_M_default_appendEm"
 build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: g++.dg/pr83239.C  -std=gnu++14  scan-tree-dump-not optimized "_ZNSt6vectorIiSaIiEE17_M_default_appendEm"
+#
+# Upstream regression, PR 86153.
+#
+build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: g++.dg/pr83239.C  -std=gnu++98 (test for excess errors)


### PR DESCRIPTION
There are two regressions.  g++.dg/pr83239.C breaks for every arch/abi combination.  This is a documented upstream regression where a fix for one bug accidentally created a new bug.  gfortran.dg/ieee/ieee_6.f90 only breaks for linux FP targets.  The libgfortran runtime library was modified to and/remove some feenableexcept and fedisableexcept calls.  I think this is triggering a latent bug in our old glibc and/or qemu that is probably already fixed in current versions.  glibc/qemu upgrades are waiting for the upstream 32-bit glibc support.
