### PR TITLE
Use -O2 for newlib and -Os for newlib nano.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -476,8 +476,8 @@ stamps/build-newlib: $(srcdir)/riscv-newlib stamps/build-gcc-newlib-stage1
 		--enable-newlib-io-long-double \
 		--enable-newlib-io-long-long \
 		--enable-newlib-io-c99-formats \
-		CFLAGS_FOR_TARGET="-Os $(CFLAGS_FOR_TARGET)" \
-		CXXFLAGS_FOR_TARGET="-Os $(CXXFLAGS_FOR_TARGET)"
+		CFLAGS_FOR_TARGET="-O2 $(CFLAGS_FOR_TARGET)" \
+		CXXFLAGS_FOR_TARGET="-O2 $(CXXFLAGS_FOR_TARGET)"
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@


### PR DESCRIPTION
We want to have both performance and size optimized versions of some routines in newlib, and for this to work, we need to have regular newlib compiled at -O2 to get the performance optimized version of the routine, and newlib-nano compiled at -Os to get the size optimized version of the routine.  This is exactly how the ARM toolchain works.  This is just fixing an oversight from the original newlib-nano submission.  I should have changed the regular newlib to use -O2 at that time.
