### PR TITLE
Build system patch from Optimitech to make nano lite-exit support work.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -476,6 +476,7 @@ stamps/build-newlib: $(srcdir)/riscv-newlib stamps/build-gcc-newlib-stage1
 		--enable-newlib-io-long-double \
 		--enable-newlib-io-long-long \
 		--enable-newlib-io-c99-formats \
+		--enable-newlib-register-fini \
 		CFLAGS_FOR_TARGET="-O2 $(CFLAGS_FOR_TARGET)" \
 		CXXFLAGS_FOR_TARGET="-O2 $(CXXFLAGS_FOR_TARGET)"
 	$(MAKE) -C $(notdir $@)
@@ -500,7 +501,6 @@ stamps/build-newlib-nano: $(srcdir)/riscv-newlib stamps/build-gcc-newlib-stage1
 		--enable-newlib-nano-formatted-io \
 		--disable-newlib-supplied-syscalls \
 		--disable-nls \
-		--enable-newlib-register-fini \
 		CFLAGS_FOR_TARGET="-Os -ffunction-sections -fdata-sections $(CFLAGS_FOR_TARGET)" \
 		CXXFLAGS_FOR_TARGET="-Os -ffunction-sections -fdata-sections $(CXXFLAGS_FOR_TARGET)"
 	$(MAKE) -C $(notdir $@)
@@ -519,6 +519,8 @@ stamps/merge-newlib-nano: stamps/build-newlib-nano stamps/build-newlib
 		$(INSTALL_DIR)/$(NEWLIB_TUPLE)/lib/$${mld}/libg_nano.a; \
 	    cp $(builddir)/install-newlib-nano/$(NEWLIB_TUPLE)/lib/$${mld}/libgloss.a\
 		$(INSTALL_DIR)/$(NEWLIB_TUPLE)/lib/$${mld}/libgloss_nano.a; \
+	    cp $(builddir)/install-newlib-nano/$(NEWLIB_TUPLE)/lib/$${mld}/crt0.o\
+		$(INSTALL_DIR)/$(NEWLIB_TUPLE)/lib/$${mld}/crt0.o; \
 	done
 # Copy nano header files into newlib install dir.
 	mkdir -p $(INSTALL_DIR)/$(NEWLIB_TUPLE)/include/newlib-nano; \


### PR DESCRIPTION
The newlib-nano --enable-lite-exit support disables support for destructors in crt0.o to reduce code size for people that don't need this.  The --enable-newlib-register-fini configure option allows destructors to run without explicit support in crt0.o, and hence should be used with regular newlib not newlib-nano.  We need to copy the nano crt0.o overtop of the regular crt0.o to make the lite-exit support work, and this still works for regular newlib because of the --enable-newlib-register-fini option.  This is the same way that the ARM embedded toolchain works.

This was tested with make checks, and there is no change to results using regular newlib, and 6 C++ testcases for destructor support fail using newlib nano which is expected.
