### PR TITLE
Support for build in minimal environments

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -25,17 +25,17 @@ WITH_TUNE ?= @WITH_TUNE@
 SYSROOT := $(INSTALL_DIR)/sysroot
 
 SHELL := /bin/sh
-AWK := @GAWK@
-SED := @GSED@
+AWK := @AWK@
+SED := @SED@
 PATH := $(INSTALL_DIR)/bin:$(PATH)
 
 # Check to see if we need wrapper scripts for awk/sed (which point to
 # gawk/gsed on platforms where these aren't the default), otherwise
 # don't override these as the wrappers don't always work.
-ifneq (@GSED@,/bin/sed)
+ifneq (@SED@,/bin/sed)
 	PATH := $(base_dir)/sed:$(PATH)
 endif
-ifneq (@GAWK@,/usr/bin/gawk)
+ifneq (@AWK@,/usr/bin/awk)
 	PATH := $(base_dir)/awk:$(PATH)
 endif
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -27,6 +27,7 @@ SYSROOT := $(INSTALL_DIR)/sysroot
 SHELL := /bin/sh
 AWK := @AWK@
 SED := @SED@
+TEXINFO := true
 PATH := $(INSTALL_DIR)/bin:$(PATH)
 
 # Check to see if we need wrapper scripts for awk/sed (which point to

--- a/Makefile.in
+++ b/Makefile.in
@@ -194,7 +194,8 @@ stamps/build-binutils-linux: $(srcdir)/riscv-binutils
 		--disable-gdb \
 		--disable-sim \
 		--disable-libdecnumber \
-		--disable-readline
+		--disable-readline \
+		--disable-nls
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
@@ -218,7 +219,8 @@ stamps/build-gdb-linux: $(srcdir)/riscv-gdb
 		--disable-binutils \
 		--disable-ld \
 		--disable-gold \
-		--disable-gprof
+		--disable-gprof \
+		--disable-nls
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
@@ -232,7 +234,8 @@ stamps/build-glibc-linux-headers: $(srcdir)/riscv-glibc stamps/build-gcc-linux-s
 		--enable-shared \
 		--with-headers=$(srcdir)/linux-headers/include \
 		--disable-multilib \
-		--enable-kernel=3.0.0
+		--enable-kernel=3.0.0 \
+		--disable-nls
 	$(MAKE) -C $(notdir $@) install-headers
 	mkdir -p $(dir $@) && touch $@
 
@@ -356,7 +359,8 @@ stamps/build-binutils-linux-native: $(srcdir)/riscv-binutils stamps/build-gcc-li
 		--disable-gdb \
 		--disable-sim \
 		--disable-libdecnumber \
-		--disable-readline
+		--disable-readline \
+		--disable-nls
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
@@ -408,7 +412,8 @@ stamps/build-binutils-newlib: $(srcdir)/riscv-binutils
 		--disable-gdb \
 		--disable-sim \
 		--disable-libdecnumber \
-		--disable-readline
+		--disable-readline \
+		--disable-nls
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
@@ -429,7 +434,8 @@ stamps/build-gdb-newlib: $(srcdir)/riscv-gdb
 		--disable-binutils \
 		--disable-ld \
 		--disable-gold \
-		--disable-gprof
+		--disable-gprof \
+		--disable-nls
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
@@ -582,7 +588,8 @@ stamps/build-binutils-musl: $(srcdir)/riscv-binutils
 		--disable-gdb \
 		--disable-sim \
 		--disable-libdecnumber \
-		--disable-readline
+		--disable-readline \
+		--disable-nls
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@

--- a/configure
+++ b/configure
@@ -602,9 +602,9 @@ FTP
 WGET
 CURL
 NEED_GCC_EXTERNAL_LIBRARIES
-GSED
-GAWK
 BASH
+AWK
+SED
 FGREP
 GREP
 OBJEXT
@@ -2826,6 +2826,117 @@ $as_echo "$ac_cv_path_GREP" >&6; }
  GREP="$ac_cv_path_GREP"
 
 
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for a sed that does not truncate output" >&5
+$as_echo_n "checking for a sed that does not truncate output... " >&6; }
+if ${ac_cv_path_SED+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+            ac_script=s/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/
+     for ac_i in 1 2 3 4 5 6 7; do
+       ac_script="$ac_script$as_nl$ac_script"
+     done
+     echo "$ac_script" 2>/dev/null | sed 99q >conftest.sed
+     { ac_script=; unset ac_script;}
+     if test -z "$SED"; then
+  ac_path_SED_found=false
+  # Loop through the user's path and test for each of PROGNAME-LIST
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_prog in sed gsed; do
+    for ac_exec_ext in '' $ac_executable_extensions; do
+      ac_path_SED="$as_dir/$ac_prog$ac_exec_ext"
+      as_fn_executable_p "$ac_path_SED" || continue
+# Check for GNU ac_path_SED and select it if it is found.
+  # Check for GNU $ac_path_SED
+case `"$ac_path_SED" --version 2>&1` in
+*GNU*)
+  ac_cv_path_SED="$ac_path_SED" ac_path_SED_found=:;;
+*)
+  ac_count=0
+  $as_echo_n 0123456789 >"conftest.in"
+  while :
+  do
+    cat "conftest.in" "conftest.in" >"conftest.tmp"
+    mv "conftest.tmp" "conftest.in"
+    cp "conftest.in" "conftest.nl"
+    $as_echo '' >> "conftest.nl"
+    "$ac_path_SED" -f conftest.sed < "conftest.nl" >"conftest.out" 2>/dev/null || break
+    diff "conftest.out" "conftest.nl" >/dev/null 2>&1 || break
+    as_fn_arith $ac_count + 1 && ac_count=$as_val
+    if test $ac_count -gt ${ac_path_SED_max-0}; then
+      # Best one so far, save it but keep looking for a better one
+      ac_cv_path_SED="$ac_path_SED"
+      ac_path_SED_max=$ac_count
+    fi
+    # 10*(2^10) chars as input seems more than enough
+    test $ac_count -gt 10 && break
+  done
+  rm -f conftest.in conftest.tmp conftest.nl conftest.out;;
+esac
+
+      $ac_path_SED_found && break 3
+    done
+  done
+  done
+IFS=$as_save_IFS
+  if test -z "$ac_cv_path_SED"; then
+    as_fn_error $? "no acceptable sed could be found in \$PATH" "$LINENO" 5
+  fi
+else
+  ac_cv_path_SED=$SED
+fi
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_path_SED" >&5
+$as_echo "$ac_cv_path_SED" >&6; }
+ SED="$ac_cv_path_SED"
+  rm -f conftest.sed
+
+for ac_prog in gawk mawk nawk awk
+do
+  # Extract the first word of "$ac_prog", so it can be a program name with args.
+set dummy $ac_prog; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_AWK+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -n "$AWK"; then
+  ac_cv_prog_AWK="$AWK" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_prog_AWK="$ac_prog"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+AWK=$ac_cv_prog_AWK
+if test -n "$AWK"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $AWK" >&5
+$as_echo "$AWK" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+  test -n "$AWK" && break
+done
+
 
 # Extract the first word of "bash", so it can be a program name with args.
 set dummy bash; ac_word=$2
@@ -2867,66 +2978,6 @@ else
 $as_echo "no" >&6; }
 fi
 
-
-
-if test -z "$GAWK"; then
-  ac_path_GAWK_found=false
-  # Loop through the user's path and test for each of PROGNAME-LIST
-  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_prog in gawk awk; do
-    for ac_exec_ext in '' $ac_executable_extensions; do
-      ac_path_GAWK="$as_dir/$ac_prog$ac_exec_ext"
-      as_fn_executable_p "$ac_path_GAWK" || continue
-if $ac_path_GAWK --version 2>&1 | $FGREP GNU >/dev/null; then :
-  ac_cv_path_GAWK=$ac_path_GAWK ac_path_GAWK_found=:
-fi
-      $ac_path_GAWK_found && break 3
-    done
-  done
-  done
-IFS=$as_save_IFS
-  if test -z "$ac_cv_path_GAWK"; then
-    as_fn_error $? "GNU Awk not found" "$LINENO" 5
-  fi
-else
-  ac_cv_path_GAWK=$GAWK
-fi
-
-GAWK=$ac_cv_path_GAWK
-
-
-if test -z "$GSED"; then
-  ac_path_GSED_found=false
-  # Loop through the user's path and test for each of PROGNAME-LIST
-  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_prog in gsed sed; do
-    for ac_exec_ext in '' $ac_executable_extensions; do
-      ac_path_GSED="$as_dir/$ac_prog$ac_exec_ext"
-      as_fn_executable_p "$ac_path_GSED" || continue
-if $ac_path_GSED --version 2>&1 | $FGREP GNU >/dev/null; then :
-  ac_cv_path_GSED=$ac_path_GSED ac_path_GSED_found=:
-fi
-      $ac_path_GSED_found && break 3
-    done
-  done
-  done
-IFS=$as_save_IFS
-  if test -z "$ac_cv_path_GSED"; then
-    as_fn_error $? "GNU sed not found" "$LINENO" 5
-  fi
-else
-  ac_cv_path_GSED=$GSED
-fi
-
-GSED=$ac_cv_path_GSED
 
 
 need_gcc_external_libraries="no"
@@ -4039,6 +4090,7 @@ gives unlimited permission to copy, distribute and modify it."
 
 ac_pwd='$ac_pwd'
 srcdir='$srcdir'
+AWK='$AWK'
 test -n "\$AWK" || AWK=awk
 _ACEOF
 

--- a/configure.ac
+++ b/configure.ac
@@ -3,21 +3,11 @@ AC_INIT(riscv-toolchain, 1.0)
 AC_PROG_CC
 AC_PROG_FGREP
 AC_PROG_GREP
+AC_PROG_SED
+AC_PROG_AWK
 
 AC_PATH_PROG([BASH], [bash],
 	[AC_MSG_ERROR([bash not found])])
-
-AC_PATH_PROGS_FEATURE_CHECK([GAWK], [gawk awk],
-	[AS_IF([$ac_path_GAWK --version 2>&1 | $FGREP GNU >/dev/null],
-		[ac_cv_path_GAWK=$ac_path_GAWK ac_path_GAWK_found=:])],
-	[AC_MSG_ERROR([GNU Awk not found])])
-AC_SUBST([GAWK], [$ac_cv_path_GAWK])
-
-AC_PATH_PROGS_FEATURE_CHECK([GSED], [gsed sed],
-	[AS_IF([$ac_path_GSED --version 2>&1 | $FGREP GNU >/dev/null],
-		[ac_cv_path_GSED=$ac_path_GSED ac_path_GSED_found=:])],
-	[AC_MSG_ERROR([GNU sed not found])])
-AC_SUBST([GSED], [$ac_cv_path_GSED])
 
 need_gcc_external_libraries="no"
 AC_CHECK_LIB(gmp, __gmpz_init, ,

--- a/scripts/wrapper/awk/awk.in
+++ b/scripts/wrapper/awk/awk.in
@@ -4,4 +4,4 @@
 # awk will invoke gawk (rather than mawk etc.).
 # We use this to work around systems with awk != gawk.
 
-exec ${AWK:-@GAWK@} "$@"
+exec ${AWK:-@AWK@} "$@"

--- a/scripts/wrapper/sed/sed.in
+++ b/scripts/wrapper/sed/sed.in
@@ -4,4 +4,4 @@
 # sed will invoke gsed (rather than FreeBSD's sed, for example).
 # We use this to work around systems with sed != gsed.
 
-exec ${SED:-@GSED@} "$@"
+exec ${SED:-@SED@} "$@"


### PR DESCRIPTION
Hi, I'm using your toolchain builder. I was disappointed at new gawk releases and I decided to use busybox's awk, because it works. I deleted gawk. Some days later I needed to build toolchain for riscv64. I've run `./configure` and gave me an error that `gawk` is not found. There some patches for that. Also I found that binutils requires `libintl.h` header. To fix it I just disabled nls support. Also I don't have texinfo installed. So I've set TEXINFO variable to "true".