### PR TITLE
Bump and fix newlib

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -477,8 +477,8 @@ stamps/build-newlib: $(srcdir)/riscv-newlib stamps/build-gcc-newlib-stage1
 		--enable-newlib-io-long-long \
 		--enable-newlib-io-c99-formats \
 		--enable-newlib-register-fini \
-		CFLAGS_FOR_TARGET="-O2 $(CFLAGS_FOR_TARGET)" \
-		CXXFLAGS_FOR_TARGET="-O2 $(CXXFLAGS_FOR_TARGET)"
+		CFLAGS_FOR_TARGET="-O2 -D_POSIX_MODE $(CFLAGS_FOR_TARGET)" \
+		CXXFLAGS_FOR_TARGET="-O2 -D_POSIX_MODE $(CXXFLAGS_FOR_TARGET)"
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@

--- a/test/gcc-linux/rv32imac-ilp32.log
+++ b/test/gcc-linux/rv32imac-ilp32.log
@@ -18,8 +18,6 @@ build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/cleanup-8.c execut
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/cleanup-9.c execution test
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/memmove-4.c scan-tree-dump-not optimized "memmove"
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/strlenopt-8.c scan-tree-dump-times strlen "memcpy \\(" 2
-build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c   -O0  execution test
-build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c   -Os  execution test
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-prof/time-profiler-2.c scan-ipa-dump-times profile "Read tp_first_run: 0" 2
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-prof/time-profiler-2.c scan-ipa-dump-times profile "Read tp_first_run: 2" 1
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-prof/time-profiler-2.c scan-ipa-dump-times profile "Read tp_first_run: 3" 1

--- a/test/gcc-linux/rv32imafdc-ilp32.log
+++ b/test/gcc-linux/rv32imafdc-ilp32.log
@@ -24,8 +24,6 @@ build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/cleanup-8.c execut
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/cleanup-9.c execution test
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/memmove-4.c scan-tree-dump-not optimized "memmove"
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/strlenopt-8.c scan-tree-dump-times strlen "memcpy \\(" 2
-build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c   -O0  execution test
-build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c   -Os  execution test
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-prof/time-profiler-2.c scan-ipa-dump-times profile "Read tp_first_run: 0" 2
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-prof/time-profiler-2.c scan-ipa-dump-times profile "Read tp_first_run: 2" 1
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-prof/time-profiler-2.c scan-ipa-dump-times profile "Read tp_first_run: 3" 1

--- a/test/gcc-linux/rv32imafdc-ilp32d.log
+++ b/test/gcc-linux/rv32imafdc-ilp32d.log
@@ -24,8 +24,6 @@ build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/cleanup-8.c execut
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/cleanup-9.c execution test
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/memmove-4.c scan-tree-dump-not optimized "memmove"
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/strlenopt-8.c scan-tree-dump-times strlen "memcpy \\(" 2
-build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c   -O0  execution test
-build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c   -Os  execution test
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-prof/time-profiler-2.c scan-ipa-dump-times profile "Read tp_first_run: 0" 2
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-prof/time-profiler-2.c scan-ipa-dump-times profile "Read tp_first_run: 2" 1
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-prof/time-profiler-2.c scan-ipa-dump-times profile "Read tp_first_run: 3" 1

--- a/test/gcc-linux/rv64imafdc-lp64.log
+++ b/test/gcc-linux/rv64imafdc-lp64.log
@@ -18,8 +18,6 @@ build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/cleanup-8.c execut
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/cleanup-9.c execution test
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/memmove-4.c scan-tree-dump-not optimized "memmove"
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/strlenopt-8.c scan-tree-dump-times strlen "memcpy \\(" 2
-build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c   -O0  execution test
-build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c   -Os  execution test
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-prof/time-profiler-2.c scan-ipa-dump-times profile "Read tp_first_run: 0" 2
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-prof/time-profiler-2.c scan-ipa-dump-times profile "Read tp_first_run: 2" 1
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-prof/time-profiler-2.c scan-ipa-dump-times profile "Read tp_first_run: 3" 1

--- a/test/gcc-linux/rv64imafdc-lp64d.log
+++ b/test/gcc-linux/rv64imafdc-lp64d.log
@@ -18,8 +18,6 @@ build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/cleanup-8.c execut
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/cleanup-9.c execution test
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/memmove-4.c scan-tree-dump-not optimized "memmove"
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/strlenopt-8.c scan-tree-dump-times strlen "memcpy \\(" 2
-build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c   -O0  execution test
-build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c   -Os  execution test
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-prof/time-profiler-2.c scan-ipa-dump-times profile "Read tp_first_run: 0" 2
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-prof/time-profiler-2.c scan-ipa-dump-times profile "Read tp_first_run: 2" 1
 build-gcc-linux-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-prof/time-profiler-2.c scan-ipa-dump-times profile "Read tp_first_run: 3" 1

--- a/test/gcc-newlib/rv32imafc-ilp32f.log
+++ b/test/gcc-newlib/rv32imafc-ilp32f.log
@@ -8,13 +8,6 @@ build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr42585.
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr42585.c scan-tree-dump-times optimized "struct _fat_ptr _ans" 0
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr81588.c scan-tree-dump-times reassoc1 "Optimizing range test [^\n\r]* and comparison" 1
 # log1p doesn't return a range error on newlib
-build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c   -O0  execution test
-build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c   -O1  execution test
-build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c   -O2  execution test
-build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
-build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
-build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c   -O3 -g  execution test
-build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c   -Os  execution test
 build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++11  scan-assembler-times nop 2
 build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++14  scan-assembler-times nop 2
 build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++98  scan-assembler-times nop 2

--- a/test/gcc-newlib/rv64imafdc-lp64d.log
+++ b/test/gcc-newlib/rv64imafdc-lp64d.log
@@ -8,13 +8,6 @@ build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr42585.
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr42585.c scan-tree-dump-times optimized "struct _fat_ptr _ans" 0
 build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/tree-ssa/pr81588.c scan-tree-dump-times reassoc1 "Optimizing range test [^\n\r]* and comparison" 1
 # log1p doesn't return a range error on newlib
-build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c   -O0  execution test
-build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c   -O1  execution test
-build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c   -O2  execution test
-build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c   -O2 -flto -fno-use-linker-plugin -flto-partition=none  execution test
-build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c   -O2 -flto -fuse-linker-plugin -fno-fat-lto-objects  execution test
-build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c   -O3 -g  execution test
-build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.sum:FAIL: gcc.dg/torture/pr68264.c   -Os  execution test
 build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++11  scan-assembler-times nop 2
 build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++14  scan-assembler-times nop 2
 build-gcc-newlib-stage2/gcc/testsuite/g++/g++.sum:FAIL: c-c++-common/patchable_function_entry-decl.c  -std=gnu++98  scan-assembler-times nop 2


### PR DESCRIPTION
- Bump newlib to 2019/07/09
    - This fix gcc testsuite: gcc.dg/torture/pr68264.c, because newlib wasn't set errno correctly for log1p and expm1
- Build newlib with POSIX mode
    - This is also needed for gcc.dg/torture/pr68264.c.
    - newlib was default to XOPEN MODE before 2018/12/6[1], but it remove XOPEN mode SVID3 mode, and change the default IEEE mode now.
    - The problem is IEEE won't set errno on several math function, so build with POSIX mode would be better for newlib.
    - For newlib nano, we might able to build with _IEEE_LIBM in future to reduce code size, and improve performance.

[1] https://sourceware.org/git/gitweb.cgi?p=newlib-cygwin.git;a=commit;h=b14a879d85b171960df789ac8ba2332004f838e0
[2] Fix for log1p and expm1: https://github.com/riscv/riscv-newlib/commit/0d24a86822a5ee73d6a6aa69e2a0118aa1e35204