### PR TITLE
Disable transactional memory support to reduce code size.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -454,6 +454,7 @@ stamps/build-gcc-newlib-stage1: $(srcdir)/riscv-gcc stamps/build-binutils-newlib
 		--disable-libquadmath \
 		--disable-libgomp \
 		--disable-nls \
+		--disable-tm-clone-registry \
 		--src=$(gccsrcdir) \
 		$(GCC_CHECKING_FLAGS) \
 		$(MULTILIB_FLAGS) \
@@ -549,6 +550,7 @@ stamps/build-gcc-newlib-stage2: $(srcdir)/riscv-gcc stamps/build-newlib \
 		--disable-libquadmath \
 		--disable-libgomp \
 		--disable-nls \
+		--disable-tm-clone-registry \
 		--src=$(gccsrcdir) \
 		$(GCC_CHECKING_FLAGS) \
 		$(MULTILIB_FLAGS) \


### PR DESCRIPTION
This uses a gcc configure option just merged in by Kito to drop the startfile support for transactional memory.  It is unlikely that anyone will ever want to use this feature on an embedded system.  ARM already builds embedded toolchains this way, and has been doing so for a while.  Though they didn't add a configure option for it, they just hacked the build process to get the same result.

Given a trivial program
int main (void) { return 0; }
Compiled for rv64gc/lp64d with -Os --specs=nano.specs, I get
   text	   data	    bss	    dec	    hex	filename
    476	    212	     56	    744	    2e8	a.out
With the patch added, I get
   text	   data	    bss	    dec	    hex	filename
    388	    212	     56	    656	    290	a.out
so that is an 88 byte reduction in program size due to smaller startfiles.
