### PR TITLE
Increase the timeout for git command.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ before_install:
   - export MAKEFLAGS="-j3"
   - export CXX=g++-6
   - export CC=gcc-6
+  - travis_wait 60 git submodule update --init --recursive
 env:
 #  - CARGS="--enable-linux  --disable-multilib --with-arch=rv32imac --with-abi=ilp32"
 #  - CARGS="--enable-linux  --disable-multilib --with-arch=rv32imafdc --with-abi=ilp32"
@@ -49,3 +50,5 @@ script:
   - travis_wait 90 scripts/wrapper/make_tail
   - travis_wait 180 scripts/wrapper/make_tail check
   - make report
+git:
+  submodules: false


### PR DESCRIPTION
The default timeout is 10 min, it not enough to clone all submodule, it take about half hour on travis-ci's machine, so I set it to 1 hour to prevent it timeout again and again during git clone.