### PR TITLE
Clean up rules for patch source, it's no longer used after using submodule

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -11,14 +11,6 @@ gccsrcdir := $(shell case $(mayberelsrcdir) in \
 		  (*)  echo ../$(mayberelsrcdir)/riscv-gcc ;; \
 		esac)
 
-PACKAGES :=
-
-DISTDIR ?= /var/cache/distfiles
-GNU_MIRROR := http://mirrors.kernel.org/gnu
-gcc_url := $(GNU_MIRROR)/gcc/gcc-$(gcc_version)/gcc-$(gcc_version).tar.gz
-glibc_url := $(GNU_MIRROR)/glibc/glibc-$(glibc_version).tar.gz
-newlib_url := ftp://sourceware.org/pub/newlib/newlib-$(newlib_version).tar.gz
-
 WITH_ARCH ?= @WITH_ARCH@
 WITH_ABI ?= @WITH_ABI@
 WITH_TUNE ?= @WITH_TUNE@
@@ -143,29 +135,6 @@ report-dhrystone: report-dhrystone-@default_target@
 report-binutils: report-binutils-@default_target@
 .PHONY: report-gdb
 report-gdb: report-gdb-@default_target@
-
-$(addprefix src/original-,$(PACKAGES)):
-	mkdir -p src
-	rm -rf $@ $(subst original-,,$@)-*
-	cd src && (cat $(DISTDIR)/$(subst src/original-,,$@)-$($(subst src/original-,,$@)_version).tar.gz || @FETCHER@ $($(subst src/original-,,$@)_url)) | tar zxf -
-	mv $(subst original-,,$@)-$($(subst src/original-,,$@)_version) $@
-
-$(addprefix src/,$(PACKAGES)): src/%: src/original-%
-	rm -rf $@ $@.tmp
-	cp -a $< $@.tmp
-	$(srcdir)/scripts/cp_s $(srcdir)/$(notdir $@) $@.tmp
-	cd $@.tmp && patch -p1 < $(srcdir)/patches/$(notdir $@)
-	if test -f $@.tmp/contrib/download_prerequisites && test "@NEED_GCC_EXTERNAL_LIBRARIES@" = "true"; then cd $@.tmp && ./contrib/download_prerequisites; fi
-	mv $@.tmp $@
-
-.PHONY: patches $(addprefix $(srcdir)/patches/,$(PACKAGES))
-$(addprefix $(srcdir)/patches/,$(PACKAGES)): $(srcdir)/patches/%: src/%
-	-cd src/$(notdir $@) && rm `cd $(srcdir)/$(notdir $@) && find . -type f`
-	-cd src && diff --exclude=manual --exclude=autom4te.cache -rupN original-$(notdir $@) $(notdir $@) | filterdiff --remove-timestamps > $@
-	$(srcdir)/scripts/cp_s $(srcdir)/$(notdir $@) $<
-
-patches: $(addprefix $(srcdir)/patches/,$(PACKAGES))
-
 
 stamps/build-linux-headers:
 	mkdir -p $(SYSROOT)/usr/
@@ -824,7 +793,7 @@ report-binutils-linux: stamps/check-binutils-linux
 	    `find build-binutils-linux/ -name *.sum |paste -sd "," -`
 
 clean:
-	rm -rf build-* $(addprefix src/,$(PACKAGES)) stamps install-newlib-nano
+	rm -rf build-* stamps install-newlib-nano
 
 .PHONY: report-gdb-newlib report-gdb-newlib-nano
 report-gdb-newlib: stamps/check-gdb-newlib


### PR DESCRIPTION
Clean up legacy build rules.