### PR TITLE
Add option to specify source tree of each component

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -2,6 +2,15 @@ srcdir := @abs_top_srcdir@
 builddir := @abs_top_builddir@
 INSTALL_DIR := @prefix@
 
+GCC_SRCDIR := @with_gcc_src@
+BINUTILS_SRCDIR := @with_binutils_src@
+NEWLIB_SRCDIR := @with_newlib_src@
+GLIBC_SRCDIR := @with_glibc_src@
+MUSL_SRCDIR := @with_musl_src@
+LINUX_HEADERS_SRCDIR := @with_linux_headers_src@
+GDB_SRCDIR := @with_gdb_src@
+
+ifeq ($(srcdir)/riscv-gcc,$(GCC_SRCDIR))
 # We need a relative source dir for the gcc configure, to make msys2 mingw64
 # builds work.  Mayberelsrcdir is relative if a relative path was used to run
 # configure, otherwise absolute, so we have to check.
@@ -10,6 +19,9 @@ gccsrcdir := $(shell case $(mayberelsrcdir) in \
 		  ([\\/]* | ?:[\\/]*)  echo $(mayberelsrcdir)/riscv-gcc ;; \
 		  (*)  echo ../$(mayberelsrcdir)/riscv-gcc ;; \
 		esac)
+else
+gccsrcdir := $(abspath $(GCC_SRCDIR))
+endif
 
 WITH_ARCH ?= @WITH_ARCH@
 WITH_ABI ?= @WITH_ABI@
@@ -155,7 +167,7 @@ stamps/build-linux-headers:
 # GLIBC
 #
 
-stamps/build-binutils-linux: $(srcdir)/riscv-binutils stamps/check-write-permission
+stamps/build-binutils-linux: $(BINUTILS_SRCDIR) stamps/check-write-permission
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 # CC_FOR_TARGET is required for the ld testsuite.
@@ -177,7 +189,7 @@ stamps/build-binutils-linux: $(srcdir)/riscv-binutils stamps/check-write-permiss
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-gdb-linux: $(srcdir)/riscv-gdb
+stamps/build-gdb-linux: $(GDB_SRCDIR)
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 # CC_FOR_TARGET is required for the ld testsuite.
@@ -201,20 +213,20 @@ stamps/build-gdb-linux: $(srcdir)/riscv-gdb
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-glibc-linux-headers: $(srcdir)/riscv-glibc stamps/build-gcc-linux-stage1
+stamps/build-glibc-linux-headers: $(GLIBC_SRCDIR) stamps/build-gcc-linux-stage1
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	cd $(notdir $@) && CC="$(GLIBC_CC_FOR_TARGET)" $</configure \
 		--host=$(LINUX_TUPLE) \
 		--prefix=$(SYSROOT)/usr \
 		--enable-shared \
-		--with-headers=$(srcdir)/linux-headers/include \
+		--with-headers=$(LINUX_HEADERS_SRCDIR) \
 		--disable-multilib \
 		--enable-kernel=3.0.0
 	$(MAKE) -C $(notdir $@) install-headers
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-glibc-linux-%: $(srcdir)/riscv-glibc stamps/build-gcc-linux-stage1
+stamps/build-glibc-linux-%: $(GLIBC_SRCDIR) stamps/build-gcc-linux-stage1
 ifeq ($(MULTILIB_FLAGS),--enable-multilib)
 	$(eval $@_ARCH := $(word 4,$(subst -, ,$@)))
 	$(eval $@_ABI := $(word 5,$(subst -, ,$@)))
@@ -240,7 +252,7 @@ endif
 		--disable-werror \
 		--enable-shared \
 		--enable-obsolete-rpc \
-		--with-headers=$(srcdir)/linux-headers/include \
+		--with-headers=$(LINUX_HEADERS_SRCDIR) \
 		$(MULTILIB_FLAGS) \
 		--enable-kernel=3.0.0 \
 		$(GLIBC_TARGET_FLAGS) \
@@ -249,7 +261,7 @@ endif
 	+flock $(SYSROOT)/.lock $(MAKE) -C $(notdir $@) install install_root=$(SYSROOT)
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-gcc-linux-stage1: $(srcdir)/riscv-gcc stamps/build-binutils-linux \
+stamps/build-gcc-linux-stage1: $(GCC_SRCDIR) stamps/build-binutils-linux \
                                stamps/build-linux-headers
 	if test -f $</contrib/download_prerequisites && test "@NEED_GCC_EXTERNAL_LIBRARIES@" == "true"; then cd $< && ./contrib/download_prerequisites; fi
 	rm -rf $@ $(notdir $@)
@@ -287,7 +299,7 @@ stamps/build-gcc-linux-stage1: $(srcdir)/riscv-gcc stamps/build-binutils-linux \
 	$(MAKE) -C $(notdir $@) inhibit-libc=true install-target-libgcc
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-gcc-linux-stage2: $(srcdir)/riscv-gcc $(addprefix stamps/build-glibc-linux-,$(GLIBC_MULTILIB_NAMES)) \
+stamps/build-gcc-linux-stage2: $(GCC_SRCDIR) $(addprefix stamps/build-glibc-linux-,$(GLIBC_MULTILIB_NAMES)) \
                                stamps/build-glibc-linux-headers
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
@@ -318,7 +330,7 @@ stamps/build-gcc-linux-stage2: $(srcdir)/riscv-gcc $(addprefix stamps/build-glib
 	cp -a $(INSTALL_DIR)/$(LINUX_TUPLE)/lib* $(SYSROOT)
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-binutils-linux-native: $(srcdir)/riscv-binutils stamps/build-gcc-linux-stage2 stamps/check-write-permission
+stamps/build-binutils-linux-native: $(BINUTILS_SRCDIR) stamps/build-gcc-linux-stage2 stamps/check-write-permission
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	cd $(notdir $@) && $</configure \
@@ -339,7 +351,7 @@ stamps/build-binutils-linux-native: $(srcdir)/riscv-binutils stamps/build-gcc-li
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-gcc-linux-native: $(srcdir)/riscv-gcc stamps/build-gcc-linux-stage2 stamps/build-binutils-linux-native
+stamps/build-gcc-linux-native: $(GCC_SRCDIR) stamps/build-gcc-linux-stage2 stamps/build-binutils-linux-native
 	if test -f $</contrib/download_prerequisites; then cd $< && ./contrib/download_prerequisites; fi
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
@@ -372,7 +384,7 @@ stamps/build-gcc-linux-native: $(srcdir)/riscv-gcc stamps/build-gcc-linux-stage2
 # NEWLIB
 #
 
-stamps/build-binutils-newlib: $(srcdir)/riscv-binutils stamps/check-write-permission
+stamps/build-binutils-newlib: $(BINUTILS_SRCDIR) stamps/check-write-permission
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 # CC_FOR_TARGET is required for the ld testsuite.
@@ -391,7 +403,7 @@ stamps/build-binutils-newlib: $(srcdir)/riscv-binutils stamps/check-write-permis
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-gdb-newlib: $(srcdir)/riscv-gdb
+stamps/build-gdb-newlib: $(GDB_SRCDIR)
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 # CC_FOR_TARGET is required for the ld testsuite.
@@ -412,7 +424,7 @@ stamps/build-gdb-newlib: $(srcdir)/riscv-gdb
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-gcc-newlib-stage1: $(srcdir)/riscv-gcc stamps/build-binutils-newlib
+stamps/build-gcc-newlib-stage1: $(GCC_SRCDIR) stamps/build-binutils-newlib
 	if test -f $</contrib/download_prerequisites && test "@NEED_GCC_EXTERNAL_LIBRARIES@" == "true"; then cd $< && ./contrib/download_prerequisites; fi
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
@@ -445,7 +457,7 @@ stamps/build-gcc-newlib-stage1: $(srcdir)/riscv-gcc stamps/build-binutils-newlib
 	$(MAKE) -C $(notdir $@) install-gcc
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-newlib: $(srcdir)/riscv-newlib stamps/build-gcc-newlib-stage1
+stamps/build-newlib: $(NEWLIB_SRCDIR) stamps/build-gcc-newlib-stage1
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	cd $(notdir $@) && $</configure \
@@ -462,7 +474,7 @@ stamps/build-newlib: $(srcdir)/riscv-newlib stamps/build-gcc-newlib-stage1
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-newlib-nano: $(srcdir)/riscv-newlib stamps/build-gcc-newlib-stage1
+stamps/build-newlib-nano: $(NEWLIB_SRCDIR) stamps/build-gcc-newlib-stage1
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	cd $(notdir $@) && $</configure \
@@ -507,7 +519,7 @@ stamps/merge-newlib-nano: stamps/build-newlib-nano stamps/build-newlib
 		$(INSTALL_DIR)/$(NEWLIB_TUPLE)/include/newlib-nano/newlib.h; \
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-gcc-newlib-stage2: $(srcdir)/riscv-gcc stamps/build-newlib \
+stamps/build-gcc-newlib-stage2: $(GCC_SRCDIR) stamps/build-newlib \
 		stamps/merge-newlib-nano
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
@@ -545,7 +557,7 @@ stamps/build-gcc-newlib-stage2: $(srcdir)/riscv-gcc stamps/build-newlib \
 # MUSL
 #
 
-stamps/build-binutils-musl: $(srcdir)/riscv-binutils stamps/check-write-permission
+stamps/build-binutils-musl: $(BINUTILS_SRCDIR) stamps/check-write-permission
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 # CC_FOR_TARGET is required for the ld testsuite.
@@ -567,7 +579,7 @@ stamps/build-binutils-musl: $(srcdir)/riscv-binutils stamps/check-write-permissi
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-gcc-musl-stage1: $(srcdir)/riscv-gcc stamps/build-binutils-musl \
+stamps/build-gcc-musl-stage1: $(GCC_SRCDIR) stamps/build-binutils-musl \
                                stamps/build-linux-headers
 	if test -f $</contrib/download_prerequisites && test "@NEED_GCC_EXTERNAL_LIBRARIES@" == "true"; then cd $< && ./contrib/download_prerequisites; fi
 	rm -rf $@ $(notdir $@)
@@ -603,20 +615,20 @@ stamps/build-gcc-musl-stage1: $(srcdir)/riscv-gcc stamps/build-binutils-musl \
 	$(MAKE) -C $(notdir $@) inhibit-libc=true install-target-libgcc
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-musl-linux-headers: $(srcdir)/riscv-musl stamps/build-gcc-musl-stage1
+stamps/build-musl-linux-headers: $(MUSL_SRCDIR) stamps/build-gcc-musl-stage1
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	cd $(notdir $@) && CC="$(MUSL_CC_FOR_TARGET)" $</configure \
 		--host=$(MUSL_TUPLE) \
 		--prefix=$(SYSROOT)/usr \
 		--enable-shared \
-		--with-headers=$(srcdir)/linux-headers/include \
+		--with-headers=$(LINUX_HEADERS_SRCDIR) \
 		--disable-multilib \
 		--enable-kernel=3.0.0
 	$(MAKE) -C $(notdir $@) install-headers
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-musl-linux: $(srcdir)/riscv-musl stamps/build-gcc-musl-stage1
+stamps/build-musl-linux: $(MUSL_SRCDIR) stamps/build-gcc-musl-stage1
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	cd $(notdir $@) && \
@@ -635,7 +647,7 @@ stamps/build-musl-linux: $(srcdir)/riscv-musl stamps/build-gcc-musl-stage1
 	+flock $(SYSROOT)/.lock $(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-gcc-musl-stage2: $(srcdir)/riscv-gcc stamps/build-musl-linux \
+stamps/build-gcc-musl-stage2: $(GCC_SRCDIR) stamps/build-musl-linux \
                                stamps/build-musl-linux-headers
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)

--- a/configure
+++ b/configure
@@ -584,6 +584,13 @@ PACKAGE_URL=''
 
 ac_subst_vars='LTLIBOBJS
 LIBOBJS
+with_linux_headers_src
+with_gdb_src
+with_musl_src
+with_glibc_src
+with_newlib_src
+with_binutils_src
+with_gcc_src
 enable_gdb
 with_guile
 with_system_zlib
@@ -667,6 +674,13 @@ with_host
 with_system_zlib
 with_guile
 enable_gdb
+with_gcc_src
+with_binutils_src
+with_newlib_src
+with_glibc_src
+with_musl_src
+with_gdb_src
+with_linux_headers_src
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1318,6 +1332,17 @@ Optional Packages:
                           nothing
   --without-system-zlib   use the builtin copy of zlib from GCC
   --with-guile            Set which guile to use, if any
+  --with-gcc-src          Set gcc source path, use builtin source by default
+  --with-binutils-src     Set binutils source path, use builtin source by
+                          default
+  --with-newlib-src       Set newlib source path, use builtin source by
+                          default
+  --with-glibc-src        Set glibc source path, use builtin source by default
+  --with-musl-src         Set musl source path, use builtin source by default
+  --with-gdb-src          Set gdb source path, use builtin source by default
+  --with-linux-headers-src
+                          Set linux-headers source path, use builtin source by
+                          default
 
 Some influential environment variables:
   CC          C compiler command
@@ -3431,6 +3456,141 @@ if test "x$enable_gdb" != xno; then :
 
 else
   enable_gdb=--disable-gdb
+
+fi
+
+
+
+{
+
+# Check whether --with-gcc-src was given.
+if test "${with_gcc_src+set}" = set; then :
+  withval=$with_gcc_src;
+else
+  with_gcc_src=default
+
+fi
+
+	  if test "x$with_gcc_src" != xdefault; then :
+  with_gcc_src=$with_gcc_src
+
+else
+  with_gcc_src="\$(srcdir)/riscv-gcc"
+
+fi
+
+	}
+{
+
+# Check whether --with-binutils-src was given.
+if test "${with_binutils_src+set}" = set; then :
+  withval=$with_binutils_src;
+else
+  with_binutils_src=default
+
+fi
+
+	  if test "x$with_binutils_src" != xdefault; then :
+  with_binutils_src=$with_binutils_src
+
+else
+  with_binutils_src="\$(srcdir)/riscv-binutils"
+
+fi
+
+	}
+{
+
+# Check whether --with-newlib-src was given.
+if test "${with_newlib_src+set}" = set; then :
+  withval=$with_newlib_src;
+else
+  with_newlib_src=default
+
+fi
+
+	  if test "x$with_newlib_src" != xdefault; then :
+  with_newlib_src=$with_newlib_src
+
+else
+  with_newlib_src="\$(srcdir)/riscv-newlib"
+
+fi
+
+	}
+{
+
+# Check whether --with-glibc-src was given.
+if test "${with_glibc_src+set}" = set; then :
+  withval=$with_glibc_src;
+else
+  with_glibc_src=default
+
+fi
+
+	  if test "x$with_glibc_src" != xdefault; then :
+  with_glibc_src=$with_glibc_src
+
+else
+  with_glibc_src="\$(srcdir)/riscv-glibc"
+
+fi
+
+	}
+{
+
+# Check whether --with-musl-src was given.
+if test "${with_musl_src+set}" = set; then :
+  withval=$with_musl_src;
+else
+  with_musl_src=default
+
+fi
+
+	  if test "x$with_musl_src" != xdefault; then :
+  with_musl_src=$with_musl_src
+
+else
+  with_musl_src="\$(srcdir)/riscv-musl"
+
+fi
+
+	}
+{
+
+# Check whether --with-gdb-src was given.
+if test "${with_gdb_src+set}" = set; then :
+  withval=$with_gdb_src;
+else
+  with_gdb_src=default
+
+fi
+
+	  if test "x$with_gdb_src" != xdefault; then :
+  with_gdb_src=$with_gdb_src
+
+else
+  with_gdb_src="\$(srcdir)/riscv-gdb"
+
+fi
+
+	}
+
+
+# Check whether --with-linux-headers-src was given.
+if test "${with_linux_headers_src+set}" = set; then :
+  withval=$with_linux_headers_src;
+else
+  with_linux_headers_src=default
+
+fi
+
+
+if test "x$with_linux_headers_src" != xdefault; then :
+  with_linux_headers_src=$with_linux_headers_src
+
+else
+  with_linux_headers_src="\$(srcdir)/linux-headers"
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -174,4 +174,36 @@ AS_IF([test "x$enable_gdb" != xno],
 	[AC_SUBST(enable_gdb, --enable-gdb)],
 	[AC_SUBST(enable_gdb, --disable-gdb)])
 
+AC_DEFUN([AX_ARG_WITH_SRC],
+	[{m4_pushdef([opt_name], with_$1_src)
+	  AC_ARG_WITH($1-src,
+		[AC_HELP_STRING([--with-$1-src],
+				[Set $1 source path, use builtin source by default])],
+		[],
+		[opt_name=default]
+		)
+	  AS_IF([test "x$opt_name" != xdefault],
+		[AC_SUBST(opt_name,$opt_name)],
+		[AC_SUBST(opt_name,"\$(srcdir)/riscv-$1")])
+	  m4_popdef([opt_name])
+	}])
+
+AX_ARG_WITH_SRC(gcc)
+AX_ARG_WITH_SRC(binutils)
+AX_ARG_WITH_SRC(newlib)
+AX_ARG_WITH_SRC(glibc)
+AX_ARG_WITH_SRC(musl)
+AX_ARG_WITH_SRC(gdb)
+
+AC_ARG_WITH(linux-headers-src,
+	[AC_HELP_STRING([--with-linux-headers-src],
+			[Set linux-headers source path, use builtin source by default])],
+	[],
+	[with_linux_headers_src=default]
+	)
+
+AS_IF([test "x$with_linux_headers_src" != xdefault],
+	[AC_SUBST(with_linux_headers_src,$with_linux_headers_src)],
+	[AC_SUBST(with_linux_headers_src,"\$(srcdir)/linux-headers")])
+
 AC_OUTPUT


### PR DESCRIPTION
Allow riscv-gnu-toolchain use external source, tested on Ubuntu 16.04, the motivation is make it more easier to re-use the build script by other build system/script.