### PR TITLE
Fix portability issues

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -142,7 +142,7 @@ stamps/check-write-permission:
 		 "'$(INSTALL_DIR)', use --prefix to specify" \
 		 "another path, or use 'sudo make' if you *REALLY* want to" \
 		 "install into '$(INSTALL_DIR)'" && exit 1)
-	rm $(INSTALL_DIR)/.test -r
+	rm -r $(INSTALL_DIR)/.test
 	mkdir -p $(dir $@) && touch $@
 
 stamps/build-linux-headers:

--- a/Makefile.in
+++ b/Makefile.in
@@ -25,10 +25,10 @@ PATH := $(INSTALL_DIR)/bin:$(PATH)
 # gawk/gsed on platforms where these aren't the default), otherwise
 # don't override these as the wrappers don't always work.
 ifneq (@GSED@,/bin/sed)
-	PATH := $(base_dir)/sed:$(PATH)
+	PATH := $(builddir)/scripts/wrapper/sed:$(PATH)
 endif
 ifneq (@GAWK@,/usr/bin/gawk)
-	PATH := $(base_dir)/awk:$(PATH)
+	PATH := $(builddir)/scripts/wrapper/awk:$(PATH)
 endif
 
 export PATH AWK SED

--- a/configure
+++ b/configure
@@ -4557,8 +4557,8 @@ which seems to be undefined.  Please make sure it is defined" >&2;}
 
 
   case $ac_file$ac_mode in
-    "scripts/wrapper/awk/awk":F) chmod +x scripts/wrapper/awk ;;
-    "scripts/wrapper/sed/sed":F) chmod +x scripts/wrapper/sed ;;
+    "scripts/wrapper/awk/awk":F) chmod +x scripts/wrapper/awk/awk ;;
+    "scripts/wrapper/sed/sed":F) chmod +x scripts/wrapper/sed/sed ;;
 
   esac
 done # for ac_tag

--- a/configure.ac
+++ b/configure.ac
@@ -127,8 +127,8 @@ AS_IF([test "x$with_cmodel" != x],
 	[AC_SUBST(cmodel, -mcmodel=medlow)])
 
 AC_CONFIG_FILES([Makefile])
-AC_CONFIG_FILES([scripts/wrapper/awk/awk], [chmod +x scripts/wrapper/awk])
-AC_CONFIG_FILES([scripts/wrapper/sed/sed], [chmod +x scripts/wrapper/sed])
+AC_CONFIG_FILES([scripts/wrapper/awk/awk], [chmod +x scripts/wrapper/awk/awk])
+AC_CONFIG_FILES([scripts/wrapper/sed/sed], [chmod +x scripts/wrapper/sed/sed])
 
 AC_ARG_WITH(host,
 	[AS_HELP_STRING([--with-host=x86_64-w64-mingw32],


### PR DESCRIPTION
These build system fixes are needed to work on FreeBSD 12.

The `awk`/`sed` wrappers appears to have been broken for some time.  They remain necessary since some makefile rules in glibc directly invoke `sed` with GNU extensions.

Additionally, BSD utilities are generally stricter about not permitting option arguments (e.g., `-r`) to follow non-option arguments, since they adhere to POSIX `getopt(3)` behavior.