### PR TITLE
Fix default LINUX_HEADERS_SRCDIR path

### DIFF
--- a/configure
+++ b/configure
@@ -3590,7 +3590,7 @@ if test "x$with_linux_headers_src" != xdefault; then :
   with_linux_headers_src=$with_linux_headers_src
 
 else
-  with_linux_headers_src="\$(srcdir)/linux-headers"
+  with_linux_headers_src="\$(srcdir)/linux-headers/include"
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -204,6 +204,6 @@ AC_ARG_WITH(linux-headers-src,
 
 AS_IF([test "x$with_linux_headers_src" != xdefault],
 	[AC_SUBST(with_linux_headers_src,$with_linux_headers_src)],
-	[AC_SUBST(with_linux_headers_src,"\$(srcdir)/linux-headers")])
+	[AC_SUBST(with_linux_headers_src,"\$(srcdir)/linux-headers/include")])
 
 AC_OUTPUT


### PR DESCRIPTION
This fixes a regression with #513:

```
running configure fragment for sysdeps/unix/sysv/linux
checking installed Linux kernel header files... missing or too old!
```

The `--with-headers` configure argument must point to the `include` subdirectory.

The alternative is to keep the default as `$(srcdir)/linux-headers` and instead specify `--with-headers=$(LINUX_HEADERS_SRCDIR)/include`, such that `LINUX_HEADERS_SRCDIR` matches `INSTALL_HDR_PATH` for the kernel's `headers_install` target.

It appears that the CI doesn't actually test the Linux toolchain.