### PR TITLE
Add configure options to set target C and C++ compiler flags.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -60,8 +60,8 @@ LINUX_TUPLE  ?= $(call make_tuple,$(XLEN),linux-gnu)
 NEWLIB_TUPLE ?= $(call make_tuple,$(XLEN),elf)
 MUSL_TUPLE ?= $(call make_tuple,$(XLEN),linux-musl)
 
-CFLAGS_FOR_TARGET := $(CFLAGS_FOR_TARGET_EXTRA) @cmodel@
-CXXFLAGS_FOR_TARGET := $(CXXFLAGS_FOR_TARGET_EXTRA) @cmodel@
+CFLAGS_FOR_TARGET := $(CFLAGS_FOR_TARGET_EXTRA) @target_cflags@ @cmodel@
+CXXFLAGS_FOR_TARGET := $(CXXFLAGS_FOR_TARGET_EXTRA) @target_cxxflags@ @cmodel@
 ASFLAGS_FOR_TARGET := $(ASFLAGS_FOR_TARGET_EXTRA) @cmodel@
 # --with-expat is required to enable XML support used by OpenOCD.
 BINUTILS_TARGET_FLAGS := --with-expat=yes $(BINUTILS_TARGET_FLAGS_EXTRA)

--- a/configure
+++ b/configure
@@ -595,6 +595,8 @@ enable_gdb
 with_guile
 with_system_zlib
 configure_host
+target_cxxflags
+target_cflags
 cmodel
 gcc_checking
 newlib_multilib_names
@@ -670,6 +672,8 @@ with_tune
 enable_multilib
 enable_gcc_checking
 with_cmodel
+with_target_cflags
+with_target_cxxflags
 with_host
 with_system_zlib
 with_guile
@@ -1327,6 +1331,8 @@ Optional Packages:
   --with-tune=rocket      Set the base RISC-V CPU, defaults to rocket
   --with-cmodel           Select the code model to use when building libc and
                           libgcc [--with-cmodel=medlow]
+  --with-target-cflags    Add extra target flags for C for library code
+  --with-target-cxxflags  Add extra target flags for C++ for library code
   --with-host=x86_64-w64-mingw32
                           Sets the host for the tools, you probably want
                           nothing
@@ -3380,6 +3386,23 @@ else
   cmodel=-mcmodel=medlow
 
 fi
+
+
+# Check whether --with-target_cflags was given.
+if test "${with_target_cflags+set}" = set; then :
+  withval=$with_target_cflags;
+fi
+
+target_cflags=$with_target_cflags
+
+
+# Check whether --with-target_cxxflags was given.
+if test "${with_target_cxxflags+set}" = set; then :
+  withval=$with_target_cxxflags;
+fi
+
+target_cxxflags=$with_target_cxxflags
+
 
 ac_config_files="$ac_config_files Makefile"
 

--- a/configure.ac
+++ b/configure.ac
@@ -126,6 +126,21 @@ AS_IF([test "x$with_cmodel" != x],
 	[AC_SUBST(cmodel, -mcmodel=$with_cmodel)],
 	[AC_SUBST(cmodel, -mcmodel=medlow)])
 
+AC_ARG_WITH(target_cflags,
+	[AS_HELP_STRING([--with-target-cflags],
+		[Add extra target flags for C for library code])],
+	[],
+	[]
+	)
+AC_SUBST(target_cflags, $with_target_cflags)
+AC_ARG_WITH(target_cxxflags,
+	[AS_HELP_STRING([--with-target-cxxflags],
+		[Add extra target flags for C++ for library code])],
+	[],
+	[]
+	)
+AC_SUBST(target_cxxflags, $with_target_cxxflags)
+
 AC_CONFIG_FILES([Makefile])
 AC_CONFIG_FILES([scripts/wrapper/awk/awk], [chmod +x scripts/wrapper/awk/awk])
 AC_CONFIG_FILES([scripts/wrapper/sed/sed], [chmod +x scripts/wrapper/sed/sed])


### PR DESCRIPTION
This is a partial fix for issue #530, allowing people to use
-mno-fdiv for library compiles.