### PR TITLE
Don't enable gcc checking by default.

### DIFF
--- a/configure
+++ b/configure
@@ -3357,16 +3357,13 @@ fi
 # Check whether --enable-gcc-checking was given.
 if test "${enable_gcc_checking+set}" = set; then :
   enableval=$enable_gcc_checking;
-else
-  enable_gcc_checking=yes
-
 fi
 
-if test "x$enable_gcc_checking" != xno; then :
-  gcc_checking=--enable-checking=yes
+if test "x$enable_gcc_checking" != x; then :
+  gcc_checking=--enable-checking=$enable_gcc_checking
 
 else
-  gcc_checking=--enable-checking=release
+  gcc_checking=""
 
 fi
 
@@ -3374,9 +3371,6 @@ fi
 # Check whether --with-cmodel was given.
 if test "${with_cmodel+set}" = set; then :
   withval=$with_cmodel;
-else
-  enable_gcc_checking=yes
-
 fi
 
 if test "x$with_cmodel" != x; then :

--- a/configure.ac
+++ b/configure.ac
@@ -110,17 +110,17 @@ AC_ARG_ENABLE(gcc-checking,
         [AS_HELP_STRING([--enable-gcc-checking],
 		[Enable gcc internal checking, it will make gcc very slow, only enable it when developing gcc @<:@--disable-gcc-checking@:>@])],
         [],
-        [enable_gcc_checking=yes]
+        []
         )
-AS_IF([test "x$enable_gcc_checking" != xno],
-	[AC_SUBST(gcc_checking, --enable-checking=yes)],
-	[AC_SUBST(gcc_checking, --enable-checking=release)])
+AS_IF([test "x$enable_gcc_checking" != x],
+	[AC_SUBST(gcc_checking, --enable-checking=$enable_gcc_checking)],
+	[AC_SUBST(gcc_checking, "")])
 
 AC_ARG_WITH(cmodel,
 	[AS_HELP_STRING([--with-cmodel],
 		[Select the code model to use when building libc and libgcc @<:@--with-cmodel=medlow@:>@])],
 	[],
-	[enable_gcc_checking=yes]
+	[]
 	)
 AS_IF([test "x$with_cmodel" != x],
 	[AC_SUBST(cmodel, -mcmodel=$with_cmodel)],


### PR DESCRIPTION
Also, support all gcc checking options instead of just yes and release.
Also, fix copy-and-paste error in cmodel support refering to gcc checking.