### PR TITLE
Add binuitls testsuite pr-24406-1 to the white list for newlib.

### DIFF
--- a/test/whitelist/binutils/newlib.log
+++ b/test/whitelist/binutils/newlib.log
@@ -7,3 +7,9 @@ FAIL: Build libpr23958.so
 # XXX: Unknown reason.
 #
 FAIL: Build pr22983
+#
+# This testcase is used to check whether the linker is work normally when both
+# the --wrap=SYMBOL and -flto are set.  This fail isn’t caused by the riscv
+# toolchain port, so we shoud skip it until the upstream fix the problem.
+#
+FAIL: Run pr24406-1


### PR DESCRIPTION
Binutils is bumped to riscv-binutils-2.33.1-rvv-0.8.x for rvv-0.8.x now, so we should
skip the pr-24406-1, too.

This testcase is used to check whether the linker is work normally when both
the --wrap=SYMBOL and -flto are set.  It seems that the current fix only can
work when the wrapped symbol `SYMBOL` is defined in the other files and will be
linked.  See the pr-24406-1 test, the `read` symbol is defined in the glibc’s
libc.so.6, and we will also link the libc.so.6 by the linux toolchain, so it
works.  But the `read` symbol isn’t defined in the newlib, or other linked
objects or archives.  Therefore, the pr-24406-1 testsuite is always failed
for riscv elf toolchain, but seems to work for riscv linux toolchain.

On the other hand, if the wrapped symbol is `read_p`, it isn't defined in the
other linked files, so we also get the error link for the linux toolchain.
The fix in upstream seems not complete.  I suppose that we shoud just skip the
pr-24406-1 testcase until upstream fix or remove it.