### PR TITLE
Add a pr69728 optimization success to the whitelist

### DIFF
--- a/test/whitelist/gcc/common.log
+++ b/test/whitelist/gcc/common.log
@@ -21,3 +21,7 @@ FAIL: c-c++-common/spec-barrier-1.c
 # XXX: Need review.
 #
 FAIL: gcc.dg/debug/dwarf2/inline5.c
+#
+# We're optimizing something that shouldn't be optimized.
+#
+XPASS: gcc.dg/graphite/pr69728.c


### PR DESCRIPTION
I'm not sure what's going on here, but as far as I can tell we're optimizing
this while the test suite thinks we shouldn't be able to.

Signed-off-by: Palmer Dabbelt <palmerdabbelt@google.com>