### PR TITLE
Fix non-portable operator in shell conditional

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -263,7 +263,7 @@ endif
 
 stamps/build-gcc-linux-stage1: $(GCC_SRCDIR) stamps/build-binutils-linux \
                                stamps/build-linux-headers
-	if test -f $</contrib/download_prerequisites && test "@NEED_GCC_EXTERNAL_LIBRARIES@" == "true"; then cd $< && ./contrib/download_prerequisites; fi
+	if test -f $</contrib/download_prerequisites && test "@NEED_GCC_EXTERNAL_LIBRARIES@" = "true"; then cd $< && ./contrib/download_prerequisites; fi
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	cd $(notdir $@) && $</configure \
@@ -425,7 +425,7 @@ stamps/build-gdb-newlib: $(GDB_SRCDIR)
 	mkdir -p $(dir $@) && touch $@
 
 stamps/build-gcc-newlib-stage1: $(GCC_SRCDIR) stamps/build-binutils-newlib
-	if test -f $</contrib/download_prerequisites && test "@NEED_GCC_EXTERNAL_LIBRARIES@" == "true"; then cd $< && ./contrib/download_prerequisites; fi
+	if test -f $</contrib/download_prerequisites && test "@NEED_GCC_EXTERNAL_LIBRARIES@" = "true"; then cd $< && ./contrib/download_prerequisites; fi
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	cd $(notdir $@) && $</configure \
@@ -581,7 +581,7 @@ stamps/build-binutils-musl: $(BINUTILS_SRCDIR) stamps/check-write-permission
 
 stamps/build-gcc-musl-stage1: $(GCC_SRCDIR) stamps/build-binutils-musl \
                                stamps/build-linux-headers
-	if test -f $</contrib/download_prerequisites && test "@NEED_GCC_EXTERNAL_LIBRARIES@" == "true"; then cd $< && ./contrib/download_prerequisites; fi
+	if test -f $</contrib/download_prerequisites && test "@NEED_GCC_EXTERNAL_LIBRARIES@" = "true"; then cd $< && ./contrib/download_prerequisites; fi
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	cd $(notdir $@) && $</configure \


### PR DESCRIPTION
Not all POSIX shells support the `==` operator from Bash's extended test command, such as dash:

```sh
$ test "true" == "true"
/bin/sh: 1: test: true: unexpected operator
```