### PR TITLE
Added python3 to Ubuntu prerequisites.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Alternatively :
 Several standard packages are needed to build the toolchain.  On Ubuntu,
 executing the following command should suffice:
 
-    $ sudo apt-get install autoconf automake autotools-dev curl libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev
+    $ sudo apt-get install autoconf automake autotools-dev curl python3 libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev
 
 On Fedora/CentOS/RHEL OS, executing the following command should suffice:
 

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ executing the following command should suffice:
 
 On Fedora/CentOS/RHEL OS, executing the following command should suffice:
 
-    $ sudo yum install autoconf automake libmpc-devel mpfr-devel gmp-devel gawk  bison flex texinfo patchutils gcc gcc-c++ zlib-devel expat-devel
+    $ sudo yum install autoconf automake python3 libmpc-devel mpfr-devel gmp-devel gawk  bison flex texinfo patchutils gcc gcc-c++ zlib-devel expat-devel
 
 On OS X, you can use [Homebrew](http://brew.sh) to install the dependencies:
 
-    $ brew install gawk gnu-sed gmp mpfr libmpc isl zlib expat
+    $ brew install python3 gawk gnu-sed gmp mpfr libmpc isl zlib expat
 
 To build the glibc (Linux) on OS X, you will need to build within a case-sensitive file
 system.  The simplest approach is to create and mount a new disk image with


### PR DESCRIPTION
Minor change to README. python3 is required at the minimum to build QEMU subrepo (for Ubuntu 18.04). I didn't check the other distros.

Working build for Docker using Ubuntu:
https://github.com/rene-fonseca/docker-riscv/blob/master/riscv32-toolchain/Dockerfile
