### PR TITLE
Add a newlib nano copy of libm.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -506,6 +506,8 @@ stamps/merge-newlib-nano: stamps/build-newlib-nano stamps/build-newlib
 	    mld=`echo $${ml} | sed -e 's/;.*$$//'`; \
 	    cp $(builddir)/install-newlib-nano/$(NEWLIB_TUPLE)/lib/$${mld}/libc.a \
 		$(INSTALL_DIR)/$(NEWLIB_TUPLE)/lib/$${mld}/libc_nano.a; \
+	    cp $(builddir)/install-newlib-nano/$(NEWLIB_TUPLE)/lib/$${mld}/libm.a \
+		$(INSTALL_DIR)/$(NEWLIB_TUPLE)/lib/$${mld}/libm_nano.a; \
 	    cp $(builddir)/install-newlib-nano/$(NEWLIB_TUPLE)/lib/$${mld}/libg.a \
 		$(INSTALL_DIR)/$(NEWLIB_TUPLE)/lib/$${mld}/libg_nano.a; \
 	    cp $(builddir)/install-newlib-nano/$(NEWLIB_TUPLE)/lib/$${mld}/libgloss.a\


### PR DESCRIPTION
The gamma functions use the reentrant structure which changes size in newlib
nano, so we need a nano specific copy of libm.a to go with libc.a.