### PR TITLE
[configure] fix unexpected operator line 3295

### DIFF
--- a/configure
+++ b/configure
@@ -3292,7 +3292,7 @@ else
 fi
 
 
-if test "x$with_abi" == xdefault; then :
+if test "x$with_abi" = 'xdefault'; then :
   case $with_arch in #(
   *rv64g* | *rv64*d*) :
     with_abi=lp64d ;; #(


### PR DESCRIPTION
equality of two strings is `=` not `==` see `test(1)`

It does in fact work with `bash` but it does not with `dash`