### PR TITLE
Bump binutils to 2.34

### DIFF
--- a/test/whitelist/binutils/newlib.log
+++ b/test/whitelist/binutils/newlib.log
@@ -7,3 +7,9 @@ FAIL: Build libpr23958.so
 # XXX: Unknown reason.
 #
 FAIL: Build pr22983
+#
+# This testcase is used to check whether the linker is work normally when both
+# the --wrap=SYMBOL and -flto are set.  This fail isn’t caused by the riscv
+# toolchain port, so we shoud skip it until the upstream fix the problem.
+#
+FAIL: Run pr24406-1


### PR DESCRIPTION
I get regression tests passed when updating binutils to 2.34 release.  Also, the binutils ld testsuite "pr-24406" still fail, Jim had mentioned before that arm-eabi toolchain build and test doesn't actually run the test for various reasons.  I'm not sure if it is important enough to worry about this for now.