### PR TITLE
Update whitelist for newlib nano

### DIFF
--- a/test/whitelist/gcc/newlib-nano.f.log
+++ b/test/whitelist/gcc/newlib-nano.f.log
@@ -1,0 +1,4 @@
+#
+# errno, failed because newlib nano didn't build with _POSIX_MODE
+#
+FAIL: gcc.dg/torture/pr68264.c

--- a/test/whitelist/gcc/newlib-nano.log
+++ b/test/whitelist/gcc/newlib-nano.log
@@ -3,6 +3,12 @@
 #
 FAIL: gcc.dg/tls/pr78796.c execution test
 #
+# freopen with stdout not work correctly for newlib
+#
+FAIL: gcc.c-torture/execute/user-printf.c
+FAIL: gcc.c-torture/execute/fprintf-2.c
+FAIL: gcc.c-torture/execute/printf-2.c
+#
 # newlib-nano didn't print out floating point by default,
 # program must link with -u_printf_float.
 #
@@ -12,3 +18,16 @@ FAIL: gcc.dg/tree-ssa/builtin-sprintf.c
 FAIL: gcc.c-torture/execute/930513-1.c
 FAIL: gcc.c-torture/execute/920501-8.c
 FAIL: gcc.c-torture/execute/ieee/920810-1.c
+FAIL: gcc.c-torture/execute/printf-2.c
+#
+# newlib nano using LITE_EXIT,  __register_exitproc won't link by default,
+# so dtor of global var not work properly.
+# Program must link with -u __register_exitproc to work properly.
+#
+FAIL: g++.dg/init/ref15.C
+FAIL: g++.old-deja/g++.other/init18.C
+FAIL: g++.old-deja/g++.pt/static11.C
+#
+# Missing dg-require-effective-target shared
+#
+FAIL: g++.dg/lto/pr87906


### PR DESCRIPTION
We forgot to update newlib nano part when updating white list for GCC 9.2 :P