### PR TITLE
Fully disable printing floats

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -490,6 +490,7 @@ stamps/build-newlib-nano: $(NEWLIB_SRCDIR) stamps/build-gcc-newlib-stage1
 		--enable-lite-exit \
 		--enable-newlib-global-atexit \
 		--enable-newlib-nano-formatted-io \
+		--disable-newlib-io-float \
 		--disable-newlib-supplied-syscalls \
 		--disable-nls \
 		CFLAGS_FOR_TARGET="-Os -ffunction-sections -fdata-sections $(CFLAGS_FOR_TARGET)" \


### PR DESCRIPTION
Our "newlib-nano" configuration effectively cripples floating-point I/O by its use of `--enable-newlib-nano-formatted-io`, in the following sense:

> Floating-point support is split out of the formatted I/O code into
> weak functions which are not linked by default.  Programs that need
> floating-point I/O support must explicitly request linking of one or
> both of the floating-point functions: _printf_float or _scanf_float.
> This can be done at link time using the -u option which can be passed
> to either gcc or ld.  The -u option forces the link to resolve those
> function references.  Floating-point format specifiers are recognized
> by default, but if the floating-point functions are not explicitly
> linked in, this may result in undefined behavior for programs that
> need floating-point I/O support.

Many users aren't aware of this functionality, and assume that floating-point I/O is completely disabled. Note that

> [...] one can use "disable-newlib-io-float"
> to further reduce code size.  In this case, the floating-point
> specifiers will not be recognized or handled, and the -u option
> will not work either.

This pull request proposes adding this option to our newlib-nano configuration, further reducing code size by (completely) disabling floating-point I/O.