### PR TITLE
Use proper kernel headers

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -159,7 +159,11 @@ stamps/check-write-permission:
 
 stamps/build-linux-headers:
 	mkdir -p $(SYSROOT)/usr/
+ifdef LINUX_HEADERS_SRCDIR
+	cp -a $(LINUX_HEADERS_SRCDIR) $(SYSROOT)/usr/
+else
 	cp -a $(srcdir)/linux-headers/include $(SYSROOT)/usr/
+endif
 	mkdir -p $(dir $@) && touch $@
 
 


### PR DESCRIPTION
Hi,

I've noticed that for some reason linux headers are always copied from the existing directory, even if option to override that path is passed.
This pull request tries to fix this.

Thanks.