### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,4 +18,4 @@
 	url = ../riscv-binutils-gdb.git
 [submodule "qemu"]
 	path = qemu
-	url = https://git.qemu.org/git/qemu.git
+	url = https://github.com/qemu/qemu.git


### PR DESCRIPTION
Changed to GitHub QEMU mirror because cloning QEMU was one of the longest segments of my build process.

I've experienced this on machines with extremely fast connections in the US, Europe, and Asia.  Figure might as well just use the mirror and spare users the waiting and QEMU's servers the traffic.  