### PR TITLE
Bump qemu to 5.0.0

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -692,7 +692,7 @@ stamps/build-qemu: $(srcdir)/qemu
 		--prefix=$(INSTALL_DIR) \
 		--target-list=riscv64-linux-user,riscv32-linux-user \
 		--interp-prefix=$(INSTALL_DIR)/sysroot \
-		--python=python2
+		--python=python3
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@)


### PR DESCRIPTION
This is preparation for bumping GCC to 10.

Qemu 5.0 will fix issues on gcc 10 ubsan testsuite fails which will got qemu assertion error on current qemu version.

The extra requirement is qemu 5 need python >= 3.5, so I also update the configure option.