### PR TITLE
Allowlist might contain XPASS and FAIL for same case in sametime

### DIFF
--- a/scripts/testsuite-filter
+++ b/scripts/testsuite-filter
@@ -128,7 +128,9 @@ def read_white_lists(white_list_files, is_gcc):
                         print ("Each line must contail <STATUS>: .*")
                         print ("e.g. FAIL: g++.dg/pr83239.C")
                         print ("Or starts with # for comment")
-                    white_lists[key] = l
+                    if key not in white_lists:
+                        white_lists[key] = []
+                    white_lists[key].append(l)
                 else:
                     white_lists.add(l)
 
@@ -206,7 +208,8 @@ def filter_result(tool, libc, white_list_base_dir, unexpected_results):
                 for ur in unexpected_result:
                     key = ur.split(' ')[1]
                     if key in white_list and \
-                       ur.startswith(white_list[key]):
+                              any(map(lambda x:ur.startswith(x),
+                                      white_list[key])):
                         # This item can be ignored
                         continue
                     else:


### PR DESCRIPTION
Current script only allow 1 testcase is XPASS or FAIL, but it could happen at same time
e.g.
The testcase already fail, the second XPASS is kind of false positive.

FAIL: gcc.dg/analyzer/taint-1.c
XPASS: gcc.dg/analyzer/taint-1.c