### PR TITLE
Precompile & Package Linux Builds Workflow

### DIFF
--- a/.github/setup-apt.sh
+++ b/.github/setup-apt.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# install OS prerequisites
+dpkg --add-architecture i386
+apt update
+apt install -y autoconf automake autotools-dev curl python3 libmpc-dev libmpfr-dev \
+            libgmp-dev gawk build-essential bison flex texinfo gperf libtool \
+            patchutils bc zlib1g-dev libexpat-dev git

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   checkout:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
@@ -30,7 +30,65 @@ jobs:
           path: source.tar.gz
 
 
-  build-riscv32:
+  build-riscv32-ubuntu_18_04:
+    needs: checkout
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: source-code-full
+      
+      # workaround https://github.com/actions/upload-artifact/issues/38
+      - name: tarball source
+        run: tar -xvf source.tar.gz
+
+      - name: install dependencies
+        run: sudo ./.github/setup-apt.sh
+      
+      - name: Build Toolchain
+        run: |
+          ./configure --prefix=/opt/riscv --with-arch=rv32gc --with-abi=ilp32d
+          sudo make -j $(nproc) linux
+
+      - name: tarball build
+        run: tar czvf riscv.tar.gz -C /opt/ riscv/
+      
+      - uses: actions/upload-artifact@v2
+        with:
+          name: riscv32-glibc-ubuntu_18_04-nightly
+          path: riscv.tar.gz
+
+
+  build-riscv64-ubuntu_18_04:
+    needs: checkout
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: source-code-full
+
+      # workaround https://github.com/actions/upload-artifact/issues/38
+      - name: tarball source
+        run: tar -xvf source.tar.gz
+      
+      - name: install dependencies
+        run: sudo ./.github/setup-apt.sh
+
+      - name: Build Toolchain
+        run: |
+          ./configure --prefix=/opt/riscv
+          sudo make -j $(nproc) linux
+
+      - name: tarball build
+        run: tar czvf riscv.tar.gz -C /opt/ riscv/
+      
+      - uses: actions/upload-artifact@v2
+        with:
+          name: riscv64-glibc-ubuntu_18_04-nightly
+          path: riscv.tar.gz   
+
+
+  build-riscv32-ubuntu_20_04:
     needs: checkout
     runs-on: ubuntu-20.04
     steps:
@@ -55,11 +113,11 @@ jobs:
       
       - uses: actions/upload-artifact@v2
         with:
-          name: riscv32-glibc-nightly
+          name: riscv32-glibc-ubuntu_20_04-nightly
           path: riscv.tar.gz
 
 
-  build-riscv64:
+  build-riscv64-ubuntu_20_04:
     needs: checkout
     runs-on: ubuntu-20.04
     steps:
@@ -84,5 +142,5 @@ jobs:
       
       - uses: actions/upload-artifact@v2
         with:
-          name: riscv64-glibc-nightly
+          name: riscv64-glibc-ubuntu_20_04-nightly
           path: riscv.tar.gz

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -1,0 +1,88 @@
+name: Packaging
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  checkout:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: initialize submodules
+        run: |
+          git submodule init
+          git submodule update --recursive --progress --recommend-shallow
+      
+      # workaround https://github.com/actions/upload-artifact/issues/38
+      - name: tarball source
+        run: |
+          base=$(basename $PWD)
+          cd ..
+          tar czvf source.tar.gz --exclude-vcs -C $base .
+          mv source.tar.gz $base/
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: source-code-full
+          path: source.tar.gz
+
+
+  build-riscv32:
+    needs: checkout
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: source-code-full
+      
+      # workaround https://github.com/actions/upload-artifact/issues/38
+      - name: tarball source
+        run: tar -xvf source.tar.gz
+
+      - name: install dependencies
+        run: sudo ./.github/setup-apt.sh
+      
+      - name: Build Toolchain
+        run: |
+          ./configure --prefix=/opt/riscv --with-arch=rv32gc --with-abi=ilp32d
+          sudo make -j $(nproc) linux
+
+      - name: tarball build
+        run: tar czvf riscv.tar.gz -C /opt/ riscv/
+      
+      - uses: actions/upload-artifact@v2
+        with:
+          name: riscv32-glibc-nightly
+          path: riscv.tar.gz
+
+
+  build-riscv64:
+    needs: checkout
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: source-code-full
+
+      # workaround https://github.com/actions/upload-artifact/issues/38
+      - name: tarball source
+        run: tar -xvf source.tar.gz
+      
+      - name: install dependencies
+        run: sudo ./.github/setup-apt.sh
+
+      - name: Build Toolchain
+        run: |
+          ./configure --prefix=/opt/riscv
+          sudo make -j $(nproc) linux
+
+      - name: tarball build
+        run: tar czvf riscv.tar.gz -C /opt/ riscv/
+      
+      - uses: actions/upload-artifact@v2
+        with:
+          name: riscv64-glibc-nightly
+          path: riscv.tar.gz

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   checkout:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 
@@ -32,7 +32,7 @@ jobs:
 
   build-riscv32:
     needs: checkout
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/download-artifact@v2
         with:
@@ -61,7 +61,7 @@ jobs:
 
   build-riscv64:
     needs: checkout
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/download-artifact@v2
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,21 +1,21 @@
 [submodule "riscv-binutils"]
 	path = riscv-binutils
-	url = ../../riscv/riscv-binutils-gdb.git
+	url = ../riscv-binutils-gdb.git
 [submodule "riscv-gcc"]
 	path = riscv-gcc
-	url = ../../riscv/riscv-gcc.git
+	url = ../riscv-gcc.git
 [submodule "riscv-glibc"]
 	path = riscv-glibc
-	url = ../../riscv/riscv-glibc.git
+	url = ../riscv-glibc.git
 [submodule "riscv-dejagnu"]
 	path = riscv-dejagnu
-	url = ../../riscv/riscv-dejagnu.git
+	url = ../riscv-dejagnu.git
 [submodule "riscv-newlib"]
 	path = riscv-newlib
-	url = ../../riscv/riscv-newlib.git
+	url = ../riscv-newlib.git
 [submodule "riscv-gdb"]
 	path = riscv-gdb
-	url = ../../riscv/riscv-binutils-gdb.git
+	url = ../riscv-binutils-gdb.git
 [submodule "qemu"]
 	path = qemu
 	url = https://git.qemu.org/git/qemu.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,21 +1,21 @@
 [submodule "riscv-binutils"]
 	path = riscv-binutils
-	url = ../riscv-binutils-gdb.git
+	url = ../../riscv/riscv-binutils-gdb.git
 [submodule "riscv-gcc"]
 	path = riscv-gcc
-	url = ../riscv-gcc.git
+	url = ../../riscv/riscv-gcc.git
 [submodule "riscv-glibc"]
 	path = riscv-glibc
-	url = ../riscv-glibc.git
+	url = ../../riscv/riscv-glibc.git
 [submodule "riscv-dejagnu"]
 	path = riscv-dejagnu
-	url = ../riscv-dejagnu.git
+	url = ../../riscv/riscv-dejagnu.git
 [submodule "riscv-newlib"]
 	path = riscv-newlib
-	url = ../riscv-newlib.git
+	url = ../../riscv/riscv-newlib.git
 [submodule "riscv-gdb"]
 	path = riscv-gdb
-	url = ../riscv-binutils-gdb.git
+	url = ../../riscv/riscv-binutils-gdb.git
 [submodule "qemu"]
 	path = qemu
 	url = https://git.qemu.org/git/qemu.git


### PR DESCRIPTION
`riscv-gnu-toolchain` takes a long time (more than 1 hour) to compile.
This GitHub workflow compiles and tarballs the toolchain which are ready to use right away.

Use case:
    * Use of `qemu-system-riscv32` requires this toolchain, and toolchain is the longest part of the setup.
    * [Website with precompiled toolchains](https://toolchains.bootlin.com) only has outdated releases.

It would be nice to utilize this workflow and create 'nightly' releases.