### PR TITLE
Vagrant plugin check so it will not fail in the middle of provisioning

### DIFF
--- a/contrib/Vagrantfile
+++ b/contrib/Vagrantfile
@@ -1,3 +1,8 @@
+# Check if required plugin is installed
+unless Vagrant.has_plugin?("vagrant-disksize")
+  raise 'The vagrant-disksize plugin is not installed! Type "vagrant plugin install vagrant-disksize" to install it.'
+end
+
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/bionic64"
   # needs vagrant plugin install vagrant-disksize:


### PR DESCRIPTION
Doing sanity check if the required plugin is present. 
If the plugin is missing, with this check it will fail straight away, in human friendly way and explaining what needs to be done to fix it.