### PR TITLE
Bump gcc and add option to configure multi-lib

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -52,7 +52,14 @@ endif
 export PATH AWK SED
 
 MULTILIB_FLAGS := @multilib_flags@
+MULTILIB_GEN := @multilib_gen@
+ifeq ($(MULTILIB_GEN),)
 NEWLIB_MULTILIB_NAMES := @newlib_multilib_names@
+GCC_MULTILIB_FLAGS := $(MULTILIB_FLAGS)
+else
+NEWLIB_MULTILIB_NAMES := $(shell echo $(MULTILIB_GEN) | $(SED) 's/;/\n/'| $(AWK) '{split($$0,a,"-"); printf "%s-%s ", a[1],a[2]}')
+GCC_MULTILIB_FLAGS := $(MULTILIB_FLAGS) --with-multilib-generator="$(MULTILIB_GEN)"
+endif
 GLIBC_MULTILIB_NAMES := @glibc_multilib_names@
 GCC_CHECKING_FLAGS := @gcc_checking@
 
@@ -490,7 +497,7 @@ stamps/build-gcc-newlib-stage1: $(GCC_SRCDIR) stamps/build-binutils-newlib
 		--disable-tm-clone-registry \
 		--src=$(gccsrcdir) \
 		$(GCC_CHECKING_FLAGS) \
-		$(MULTILIB_FLAGS) \
+		$(GCC_MULTILIB_FLAGS) \
 		$(WITH_ABI) \
 		$(WITH_ARCH) \
 		$(WITH_TUNE) \
@@ -588,7 +595,7 @@ stamps/build-gcc-newlib-stage2: $(GCC_SRCDIR) stamps/build-newlib \
 		--disable-tm-clone-registry \
 		--src=$(gccsrcdir) \
 		$(GCC_CHECKING_FLAGS) \
-		$(MULTILIB_FLAGS) \
+		$(GCC_MULTILIB_FLAGS) \
 		$(WITH_ABI) \
 		$(WITH_ARCH) \
 		$(WITH_TUNE) \

--- a/README.md
+++ b/README.md
@@ -127,6 +127,42 @@ devtoolset-7 works.
 There are a number of additional options that may be passed to
 configure.  See './configure --help' for more details.
 
+#### Build with customized multi-lib configure.
+
+`--with-multilib-generator=` can specify what multilibs to build.  The argument
+is a semicolon separated list of values, possibly consisting of a single value.
+Currently only supported for riscv*-*-elf*.  The accepted values and meanings
+are given below.
+
+Every config is constructed with four components: architecture string, ABI,
+reuse rule with architecture string and reuse rule with sub-extension.
+
+Re-use part support expansion operator (*) to simplify the combination of
+different sub-extensions, example 4 demonstrate how it uses and works.
+
+Example 1: Add multi-lib suppport for rv32i with ilp32.
+```
+./configure --with-multilib-generator="rv32i-ilp32--"
+```
+
+Example 2: Add multi-lib suppport for rv32i with ilp32 and rv32imafd with ilp32.
+
+```
+./configure --with-multilib-generator="rv32i-ilp32--;rv32imafd-ilp32--"
+```
+
+Example 3: Add multi-lib suppport for rv32i with ilp32; rv32im with ilp32 and
+rv32ic with ilp32 will reuse this multi-lib set.
+```
+./configure --with-multilib-generator="rv32i-ilp32-rv32im-c"
+```
+
+Example 4: Add multi-lib suppport for rv64ima with lp64; rv64imaf with lp64,
+rv64imac with lp64 and rv64imafc with lp64 will reuse this multi-lib set.
+```
+./configure --with-multilib-generator="rv64ima-lp64--f*c"
+```
+
 ### Test Suite
 
 The Dejagnu test suite has been ported to RISC-V. This can be run with a

--- a/configure
+++ b/configure
@@ -602,6 +602,7 @@ gcc_checking
 newlib_multilib_names
 glibc_multilib_names
 multilib_flags
+multilib_gen
 WITH_TUNE
 WITH_ABI
 WITH_ARCH
@@ -670,6 +671,7 @@ with_arch
 with_abi
 with_tune
 enable_multilib
+with_multilib_generator
 enable_gcc_checking
 with_cmodel
 with_target_cflags
@@ -1329,6 +1331,10 @@ Optional Packages:
   --with-arch=rv64imafdc  Sets the base RISC-V ISA, defaults to rv64imafdc
   --with-abi=lp64d        Sets the base RISC-V ABI, defaults to lp64d
   --with-tune=rocket      Set the base RISC-V CPU, defaults to rocket
+  --with-multilib-generator
+                          Multi-libs configuration string, only supported for
+                          bare-metal/elf toolchaih, this option implied
+                          --enable-multilib
   --with-cmodel           Select the code model to use when building libc and
                           libgcc [--with-cmodel=medlow]
   --with-target-cflags    Add extra target flags for C for library code
@@ -3330,7 +3336,26 @@ else
 fi
 
 
-if test "x$enable_multilib" != xno; then :
+
+# Check whether --with-multilib-generator was given.
+if test "${with_multilib_generator+set}" = set; then :
+  withval=$with_multilib_generator;
+else
+  with_multilib_generator=no
+
+fi
+
+
+if test "x$with_multilib_generator" != xno; then :
+  multilib_gen="$with_multilib_generator"
+
+else
+  multilib_gen=""
+
+fi
+
+
+if test "x$enable_multilib" != xno || test "x$with_multilib_generator" != xno; then :
   multilib_flags=--enable-multilib
 
 else

--- a/configure.ac
+++ b/configure.ac
@@ -94,7 +94,19 @@ AC_ARG_ENABLE(multilib,
 	[enable_multilib=no]
 	)
 
-AS_IF([test "x$enable_multilib" != xno],
+AC_ARG_WITH(multilib-generator,
+	[AS_HELP_STRING([--with-multilib-generator],
+		[Multi-libs configuration string, only supported for bare-metal/elf toolchaih, this option implied --enable-multilib])],
+	[],
+	[with_multilib_generator=no]
+	)
+
+AS_IF([test "x$with_multilib_generator" != xno],
+        [AC_SUBST(multilib_gen,"$with_multilib_generator")],
+        [AC_SUBST(multilib_gen,"")])
+
+
+AS_IF([test "x$enable_multilib" != xno || test "x$with_multilib_generator" != xno],
         [AC_SUBST(multilib_flags,--enable-multilib)],
 	[AC_SUBST(multilib_flags,--disable-multilib)])
 


### PR DESCRIPTION
Backport following patches from upstream:

   - RISC-V: Check multiletter extension has more than 1 letter
   - RISC-V: Add configure option: --with-multilib-generator to flexible config multi-lib settings.
   - RISC-V: Refine riscv_parse_arch_string
   - RISC-V: Extend syntax for the multilib-generator
   - RISC-V: Handle implied extension in multilib-generator
   - RISC-V: Add support for -mcpu option.
   - RISC-V: Define __riscv_cmodel_medany for PIC mode.

And add --with-multilib-generator to configure script