### PR TITLE
Fix simulator dependency for spike

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -173,10 +173,10 @@ SIM_PATH:=$(srcdir)/scripts/wrapper/spike
 SIM_PREPARE:=PATH="$(SIM_PATH):$(INSTALL_DIR)/bin:$(PATH)" PK_PATH="$(INSTALL_DIR)/$(NEWLIB_TUPLE)/bin/"
 SIM_STAMP:= stamps/build-spike
 ifneq (,$(findstring rv32,$(NEWLIB_MULTILIB_NAMES)))
-SIM_STAMP:= stamps/build-pk32
+SIM_STAMP+= stamps/build-pk32
 endif
 ifneq (,$(findstring rv64,$(NEWLIB_MULTILIB_NAMES)))
-SIM_STAMP:= stamps/build-pk64
+SIM_STAMP+= stamps/build-pk64
 endif
 else
 ifeq ($(SIM),gdb)


### PR DESCRIPTION
`spike` and `pk` should both listed SIM_STAMP when `SIM=spike`.