### PR TITLE
Disable libsanitizer when building the musl-based toolchain

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -704,6 +704,8 @@ stamps/build-gcc-musl-stage2: $(GCC_SRCDIR) stamps/build-musl-linux \
                                stamps/build-musl-linux-headers
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
+	# Disable libsanitizer for now
+	# https://github.com/google/sanitizers/issues/1080
 	cd $(notdir $@) && $</configure \
 		--target=$(MUSL_TUPLE) \
 		$(CONFIGURE_HOST) \
@@ -716,6 +718,7 @@ stamps/build-gcc-musl-stage2: $(GCC_SRCDIR) stamps/build-musl-linux \
 		--disable-libmudflap \
 		--disable-libssp \
 		--disable-libquadmath \
+		--disable-libsanitizer \
 		--disable-nls \
 		--disable-bootstrap \
 		--src=$(gccsrcdir) \


### PR DESCRIPTION
This allows building the musl-based toolchain again, tested
with the latest stable version of musl-libc.