### PR TITLE
Bump and switch to using upstream repo for newlib

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	url = ../riscv-dejagnu.git
 [submodule "riscv-newlib"]
 	path = riscv-newlib
-	url = ../riscv-newlib.git
+	url = git://sourceware.org/git/newlib-cygwin.git
 [submodule "riscv-gdb"]
 	path = riscv-gdb
 	url = ../riscv-binutils-gdb.git


### PR DESCRIPTION
Bump to 4.1.0 newlib which included semi-hosting support and several libm improvement, verified with regression.