### PR TITLE
Automatically download sub-module on-demand and add branch info.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,21 +1,27 @@
 [submodule "riscv-binutils"]
 	path = riscv-binutils
 	url = ../riscv-binutils-gdb.git
+	branch = riscv-binutils-2.35
 [submodule "riscv-gcc"]
 	path = riscv-gcc
 	url = ../riscv-gcc.git
+	branch = riscv-gcc-10.2.0
 [submodule "riscv-glibc"]
 	path = riscv-glibc
 	url = ../riscv-glibc.git
+	branch = riscv-glibc-2.29
 [submodule "riscv-dejagnu"]
 	path = riscv-dejagnu
 	url = ../riscv-dejagnu.git
+	branch = riscv-dejagnu-1.6
 [submodule "riscv-newlib"]
 	path = riscv-newlib
 	url = git://sourceware.org/git/newlib-cygwin.git
+	branch = master
 [submodule "riscv-gdb"]
 	path = riscv-gdb
 	url = ../riscv-binutils-gdb.git
+	branch = fsf-gdb-10.1-with-sim
 [submodule "qemu"]
 	path = qemu
 	url = https://git.qemu.org/git/qemu.git

--- a/Makefile.in
+++ b/Makefile.in
@@ -209,12 +209,50 @@ else
 endif
 	mkdir -p $(dir $@) && touch $@
 
+#
+# Rule for auto init submodules
+#
+
+ifeq ($(findstring $(srcdir),$(GCC_SRCDIR)),$(srcdir))
+GCC_SRC_GIT := $(GCC_SRCDIR)/.git
+else
+GCC_SRC_GIT :=
+endif
+
+ifeq ($(findstring $(srcdir),$(BINUTILS_SRCDIR)),$(srcdir))
+BINUTILS_SRC_GIT := $(BINUTILS_SRCDIR)/.git
+else
+BINUTILS_SRC_GIT :=
+endif
+
+ifeq ($(findstring $(srcdir),$(GDB_SRCDIR)),$(srcdir))
+GDB_SRC_GIT := $(GDB_SRCDIR)/.git
+else
+GDB_SRC_GIT :=
+endif
+
+ifeq ($(findstring $(srcdir),$(NEWLIB_SRCDIR)),$(srcdir))
+NEWLIB_SRC_GIT := $(NEWLIB_SRCDIR)/.git
+else
+NEWLIB_SRC_GIT :=
+endif
+
+ifeq ($(findstring $(srcdir),$(GLIBC_SRCDIR)),$(srcdir))
+GLIBC_SRC_GIT := $(GLIBC_SRCDIR)/.git
+else
+GLIBC_SRC_GIT :=
+endif
+
+$(srcdir)/%/.git:
+	cd $(srcdir) && \
+	flock $(srcdir)/.git/config git submodule init $(dir $@) && \
+	flock $(srcdir)/.git/config git submodule update --single-branch $(dir $@)
 
 #
 # GLIBC
 #
 
-stamps/build-binutils-linux: $(BINUTILS_SRCDIR) stamps/check-write-permission
+stamps/build-binutils-linux: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) stamps/check-write-permission
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 # CC_FOR_TARGET is required for the ld testsuite.
@@ -236,7 +274,7 @@ stamps/build-binutils-linux: $(BINUTILS_SRCDIR) stamps/check-write-permission
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-gdb-linux: $(GDB_SRCDIR)
+stamps/build-gdb-linux: $(GDB_SRCDIR) $(GDB_SRC_GIT)
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 # CC_FOR_TARGET is required for the ld testsuite.
@@ -260,7 +298,7 @@ stamps/build-gdb-linux: $(GDB_SRCDIR)
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-glibc-linux-headers: $(GLIBC_SRCDIR) stamps/build-gcc-linux-stage1
+stamps/build-glibc-linux-headers: $(GLIBC_SRCDIR) $(GLIBC_SRC_GIT) stamps/build-gcc-linux-stage1
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	cd $(notdir $@) && CC="$(GLIBC_CC_FOR_TARGET)" $</configure \
@@ -273,7 +311,7 @@ stamps/build-glibc-linux-headers: $(GLIBC_SRCDIR) stamps/build-gcc-linux-stage1
 	$(MAKE) -C $(notdir $@) install-headers
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-glibc-linux-%: $(GLIBC_SRCDIR) stamps/build-gcc-linux-stage1
+stamps/build-glibc-linux-%: $(GLIBC_SRCDIR) $(GLIBC_SRC_GIT) stamps/build-gcc-linux-stage1
 ifeq ($(MULTILIB_FLAGS),--enable-multilib)
 	$(eval $@_ARCH := $(word 4,$(subst -, ,$@)))
 	$(eval $@_ABI := $(word 5,$(subst -, ,$@)))
@@ -308,7 +346,7 @@ endif
 	+flock $(SYSROOT)/.lock $(MAKE) -C $(notdir $@) install install_root=$(SYSROOT)
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-gcc-linux-stage1: $(GCC_SRCDIR) stamps/build-binutils-linux \
+stamps/build-gcc-linux-stage1: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-binutils-linux \
                                stamps/build-linux-headers
 	if test -f $</contrib/download_prerequisites && test "@NEED_GCC_EXTERNAL_LIBRARIES@" = "true"; then cd $< && ./contrib/download_prerequisites; fi
 	rm -rf $@ $(notdir $@)
@@ -346,7 +384,7 @@ stamps/build-gcc-linux-stage1: $(GCC_SRCDIR) stamps/build-binutils-linux \
 	$(MAKE) -C $(notdir $@) inhibit-libc=true install-target-libgcc
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-gcc-linux-stage2: $(GCC_SRCDIR) $(addprefix stamps/build-glibc-linux-,$(GLIBC_MULTILIB_NAMES)) \
+stamps/build-gcc-linux-stage2: $(GCC_SRCDIR) $(GCC_SRC_GIT) $(addprefix stamps/build-glibc-linux-,$(GLIBC_MULTILIB_NAMES)) \
                                stamps/build-glibc-linux-headers
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
@@ -381,7 +419,7 @@ stamps/build-gcc-linux-stage2: $(GCC_SRCDIR) $(addprefix stamps/build-glibc-linu
 	cp -a $(INSTALL_DIR)/$(LINUX_TUPLE)/lib* $(SYSROOT)
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-binutils-linux-native: $(BINUTILS_SRCDIR) stamps/build-gcc-linux-stage2 stamps/check-write-permission
+stamps/build-binutils-linux-native: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) stamps/build-gcc-linux-stage2 stamps/check-write-permission
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	cd $(notdir $@) && $</configure \
@@ -402,7 +440,7 @@ stamps/build-binutils-linux-native: $(BINUTILS_SRCDIR) stamps/build-gcc-linux-st
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-gcc-linux-native: $(GCC_SRCDIR) stamps/build-gcc-linux-stage2 stamps/build-binutils-linux-native
+stamps/build-gcc-linux-native: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-gcc-linux-stage2 stamps/build-binutils-linux-native
 	if test -f $</contrib/download_prerequisites; then cd $< && ./contrib/download_prerequisites; fi
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
@@ -435,7 +473,7 @@ stamps/build-gcc-linux-native: $(GCC_SRCDIR) stamps/build-gcc-linux-stage2 stamp
 # NEWLIB
 #
 
-stamps/build-binutils-newlib: $(BINUTILS_SRCDIR) stamps/check-write-permission
+stamps/build-binutils-newlib: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) stamps/check-write-permission
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 # CC_FOR_TARGET is required for the ld testsuite.
@@ -454,7 +492,7 @@ stamps/build-binutils-newlib: $(BINUTILS_SRCDIR) stamps/check-write-permission
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-gdb-newlib: $(GDB_SRCDIR)
+stamps/build-gdb-newlib: $(GDB_SRCDIR) $(GDB_SRC_GIT)
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 # CC_FOR_TARGET is required for the ld testsuite.
@@ -475,7 +513,7 @@ stamps/build-gdb-newlib: $(GDB_SRCDIR)
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-gcc-newlib-stage1: $(GCC_SRCDIR) stamps/build-binutils-newlib
+stamps/build-gcc-newlib-stage1: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-binutils-newlib
 	if test -f $</contrib/download_prerequisites && test "@NEED_GCC_EXTERNAL_LIBRARIES@" = "true"; then cd $< && ./contrib/download_prerequisites; fi
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
@@ -508,7 +546,7 @@ stamps/build-gcc-newlib-stage1: $(GCC_SRCDIR) stamps/build-binutils-newlib
 	$(MAKE) -C $(notdir $@) install-gcc
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-newlib: $(NEWLIB_SRCDIR) stamps/build-gcc-newlib-stage1
+stamps/build-newlib: $(NEWLIB_SRCDIR) $(NEWLIB_SRC_GIT) stamps/build-gcc-newlib-stage1
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	cd $(notdir $@) && $</configure \
@@ -525,7 +563,7 @@ stamps/build-newlib: $(NEWLIB_SRCDIR) stamps/build-gcc-newlib-stage1
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-newlib-nano: $(NEWLIB_SRCDIR) stamps/build-gcc-newlib-stage1
+stamps/build-newlib-nano: $(NEWLIB_SRCDIR) $(NEWLIB_SRC_GIT) stamps/build-gcc-newlib-stage1
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	cd $(notdir $@) && $</configure \
@@ -572,7 +610,7 @@ stamps/merge-newlib-nano: stamps/build-newlib-nano stamps/build-newlib
 		$(INSTALL_DIR)/$(NEWLIB_TUPLE)/include/newlib-nano/newlib.h; \
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-gcc-newlib-stage2: $(GCC_SRCDIR) stamps/build-newlib \
+stamps/build-gcc-newlib-stage2: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-newlib \
 		stamps/merge-newlib-nano
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
@@ -610,7 +648,7 @@ stamps/build-gcc-newlib-stage2: $(GCC_SRCDIR) stamps/build-newlib \
 # MUSL
 #
 
-stamps/build-binutils-musl: $(BINUTILS_SRCDIR) stamps/check-write-permission
+stamps/build-binutils-musl: $(BINUTILS_SRCDIR) $(BINUTILS_SRC_GIT) stamps/check-write-permission
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 # CC_FOR_TARGET is required for the ld testsuite.
@@ -632,7 +670,7 @@ stamps/build-binutils-musl: $(BINUTILS_SRCDIR) stamps/check-write-permission
 	$(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-gcc-musl-stage1: $(GCC_SRCDIR) stamps/build-binutils-musl \
+stamps/build-gcc-musl-stage1: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-binutils-musl \
                                stamps/build-linux-headers
 	if test -f $</contrib/download_prerequisites && test "@NEED_GCC_EXTERNAL_LIBRARIES@" = "true"; then cd $< && ./contrib/download_prerequisites; fi
 	rm -rf $@ $(notdir $@)
@@ -700,7 +738,7 @@ stamps/build-musl-linux: $(MUSL_SRCDIR) stamps/build-gcc-musl-stage1
 	+flock $(SYSROOT)/.lock $(MAKE) -C $(notdir $@) install
 	mkdir -p $(dir $@) && touch $@
 
-stamps/build-gcc-musl-stage2: $(GCC_SRCDIR) stamps/build-musl-linux \
+stamps/build-gcc-musl-stage2: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-musl-linux \
                                stamps/build-musl-linux-headers
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
@@ -774,7 +812,7 @@ stamps/build-pk64: pk-src stamps/build-gcc-newlib-stage2
 	mkdir -p $(dir $@)
 	date > $@
 
-stamps/build-qemu: $(srcdir)/qemu
+stamps/build-qemu: $(srcdir)/qemu $(srcdir)/qemu/.git
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	cd $(notdir $@) && $</configure \
@@ -787,7 +825,7 @@ stamps/build-qemu: $(srcdir)/qemu
 	mkdir -p $(dir $@)
 	date > $@
 
-stamps/build-dejagnu: $(srcdir)/riscv-dejagnu
+stamps/build-dejagnu: $(srcdir)/riscv-dejagnu $(srcdir)/riscv-dejagnu/.git
 	rm -rf $@ $(notdir $@)
 	mkdir $(notdir $@)
 	cd $(notdir $@) && $</configure \

--- a/Makefile.in
+++ b/Makefile.in
@@ -246,7 +246,7 @@ endif
 $(srcdir)/%/.git:
 	cd $(srcdir) && \
 	flock $(srcdir)/.git/config git submodule init $(dir $@) && \
-	flock $(srcdir)/.git/config git submodule update --single-branch $(dir $@)
+	flock $(srcdir)/.git/config git submodule update $(dir $@)
 
 #
 # GLIBC

--- a/README.md
+++ b/README.md
@@ -9,16 +9,11 @@ toolchain.
 
 ###  Getting the sources
 
-This repository uses submodules. You need the --recursive option to fetch the submodules automatically
-
-    $ git clone --recursive https://github.com/riscv/riscv-gnu-toolchain
-    
-Alternatively :
+This repository uses submodules, but submodules will fetch automatically on demand,
+so `--recursive` or `git submodule update --init --recursive` is not needed.
 
     $ git clone https://github.com/riscv/riscv-gnu-toolchain
-    $ cd riscv-gnu-toolchain
-    $ git submodule update --init --recursive
-    
+
 **Warning: git clone takes around 6.65 GB of disk and download size**
 
 ### Prerequisites


### PR DESCRIPTION
- Download sub-module on-demand
  - Don't need to download all submodule before build.
- Specify branch info in .gitmodules
  - Set by `git submodule set-branch --branch <branch-name> <submodule>`