### PR TITLE
Automatic Nightly Release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,12 +1,15 @@
-name: Packaging
+name: Build
 
 on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
-  package:
+  build:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -20,7 +23,7 @@ jobs:
         run: |
           git submodule init
           git submodule update --recursive --progress --recommend-shallow
-
+   
       - name: install dependencies
         run: sudo ./.github/setup-apt.sh
 

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -1,0 +1,215 @@
+name: Nightly Release
+
+on:
+  schedule:
+    - cron:  '0 0 * * ?'
+
+
+jobs:
+  activity-check:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    outputs:
+      stale: ${{ steps.activity_check.outputs.stale }}
+    steps:
+      - name:  Activity check
+        id: activity_check
+        run:   |
+          curl -sL https://api.github.com/repos/$GITHUB_REPOSITORY/commits | jq -r '[.[]][0]' > $HOME/commit.json
+          date="$(jq -r '.commit.author.date' $HOME/commit.json)"
+          timestamp=$(date --utc -d "$date" +%s)
+          author="$(jq -r '.commit.author.name' $HOME/commit.json)"
+          url="$(jq -r '.html_url' $HOME/commit.json)"
+          hours=$(( ( $(date --utc +%s) - $timestamp ) / 3600 ))
+          rm -f $HOME/commit.json
+          echo "Latest Repository activity : $timestamp $author $url"
+
+          STALE=false
+          if [ "${{ github.event_name }}" == "repository_dispatch" ]; then
+              echo "[WARNING] Ignoring activity limits : workflow triggered manually"
+          else
+              echo Repository active last $hours hours ago
+              if [ $hours -ge 24 ]; then
+                echo "[ERROR] Repository not updated : event<${{ github.event_name }}> not allowed to modify stale repository"
+                STALE=true
+              fi
+          fi
+          echo "::set-output name=stale::$STALE"
+          
+          if [ "$STALE" == "true" ]; then
+            exit 1
+          fi
+        shell: bash
+
+
+  checkout:
+    needs: activity-check
+    if: needs.activity-check.outputs.stale != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: initialize submodules
+        run: |
+          git submodule init
+          git submodule update --recursive --progress --recommend-shallow
+      
+      # workaround https://github.com/actions/upload-artifact/issues/38
+      - name: tarball source
+        run: |
+          base=$(basename $PWD)
+          cd ..
+          tar czvf source.tar.gz --exclude-vcs -C $base .
+          mv source.tar.gz $base/
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: full-source
+          path: source.tar.gz
+
+
+  build-ubuntu:
+    needs: checkout
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-18.04, ubuntu-20.04 ]
+        bits: [ 64, 32 ]
+    name: build riscv${{ matrix.bits }}-${{ matrix.os }}
+    env:
+      BUILD_BITS: ${{ matrix.bits }}
+    
+    steps:
+      - name: Set build environment variables
+        run: |
+          if [ "$BUILD_BITS" = "64" ]
+          then
+            echo BUILD_ARCH="rv64imafdc" >> $GITHUB_ENV
+            echo BUILD_ABI="lp64d" >> $GITHUB_ENV
+          elif [ "$BUILD_BITS" = "32" ]
+          then
+            echo BUILD_ARCH="rv32gc" >> $GITHUB_ENV
+            echo BUILD_ABI="ilp32d" >> $GITHUB_ENV
+          else
+            echo "Unsupported architecture: $BUILD_BITS bits"
+            exit 1
+          fi
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: full-source
+      
+      # workaround https://github.com/actions/upload-artifact/issues/38
+      - name: tarball source
+        run: tar -xvf source.tar.gz
+
+      - name: install apt dependencies
+        run: sudo ./.github/setup-apt.sh
+      
+      - name: Build Toolchain
+        run: |
+          ./configure --prefix=/opt/riscv --with-arch=${BUILD_ARCH} --with-abi=${BUILD_ABI}
+          sudo make -j $(nproc) linux
+
+      - name: tarball build
+        run: tar czvf riscv.tar.gz -C /opt/ riscv/
+      
+      - uses: actions/upload-artifact@v2
+        name: upload build as an artifact
+        with:
+          name: riscv${{ matrix.bits }}-${{ matrix.os }}
+          path: riscv.tar.gz
+
+
+  create-release:
+    needs: [ build-ubuntu ]
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+      asset_matrix: ${{ steps.asset_names.outputs.asset_matrix }}
+      datestamp: ${{ env.DATESTAMP }}
+    steps:
+
+      - name:  Run Configuration Commands
+        run: |
+          DATESTAMP="$(date --utc '+%Y.%m.%d')"
+          echo "Version: ${DATESTAMP}-nightly"
+
+          # Setup Artifacts Directory
+          ARTIFACTS_DIR="/opt/artifacts/"
+          mkdir -p $ARTIFACTS_DIR
+
+          # Setup environment variables
+          echo "DATESTAMP=${DATESTAMP}" >> $GITHUB_ENV
+          echo "DATEWORD=$(date --utc '+%B %d, %Y')" >> $GITHUB_ENV
+          echo "ARTIFACTS_DIR=${ARTIFACTS_DIR}" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.DATESTAMP }}
+          release_name: "Nightly: ${{ env.DATEWORD }}"
+          body: |
+            **Automated Nightly Release**
+            ${{ env.DATESTAMP }}-nightly
+          draft: false
+          prerelease: true
+
+      - name: Download Built Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: ${{ env.ARTIFACTS_DIR }}
+
+      # IMPORTANT: Each artifact must only have one file
+      - name: Designate Asset Names
+        id: asset_names
+        run: |
+          ASSET_MATRIX=$(
+            find ${ARTIFACTS_DIR} -mindepth 2 -maxdepth 2 -type f |
+            awk '{
+              fs_n=split($0, fs, "/")   # Split file paths
+              art_name=fs[fs_n-1]       # Get artifact name
+              fname=fs[fs_n]            # Get file name from the artifact
+              ext = substr(fs[fs_n], index(fs[fs_n],"."))   # File Extension
+
+              print art_name ":" fname ":" ext # format <artifact name : artifact file : file extension>
+            }' |
+            jq -R -s -c 'split("\n") | .[:-1] | {   # Split by newlines (remove last entry)
+              include: [
+                .[] | split(":") | {    # Put it in JSON format
+                  artifact: .[0],
+                  file: .[1],
+                  extension: .[2]
+                }
+              ] 
+            }'
+          )
+
+          echo "::set-output name=asset_matrix::${ASSET_MATRIX}"
+        shell: bash
+
+
+  upload-assets:
+    needs: create-release
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJson( needs.create-release.outputs.asset_matrix ) }}
+    name: upload ${{ matrix.artifact }}
+    steps:
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.artifact }}
+
+      - uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: ${{ matrix.file }}
+          asset_name: ${{ matrix.artifact }}-${{ needs.create-release.outputs.datestamp }}-nightly${{ matrix.extension }}
+          asset_content_type: application/gzip

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -42,10 +42,15 @@ jobs:
         shell: bash
 
 
-  checkout:
+  build:
     needs: activity-check
     if: needs.activity-check.outputs.stale != 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:     [ubuntu-18.04, ubuntu-20.04]
+        mode:   [newlib, linux]
+        target: [rv32gc-ilp32d, rv64gc-lp64d]
     steps:
       - uses: actions/checkout@v2
 
@@ -53,76 +58,34 @@ jobs:
         run: |
           git submodule init
           git submodule update --recursive --progress --recommend-shallow
-      
-      # workaround https://github.com/actions/upload-artifact/issues/38
-      - name: tarball source
-        run: |
-          base=$(basename $PWD)
-          cd ..
-          tar czvf source.tar.gz --exclude-vcs -C $base .
-          mv source.tar.gz $base/
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: full-source
-          path: source.tar.gz
-
-
-  build-ubuntu:
-    needs: checkout
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04 ]
-        bits: [ 64, 32 ]
-    name: build riscv${{ matrix.bits }}-${{ matrix.os }}
-    env:
-      BUILD_BITS: ${{ matrix.bits }}
-    
-    steps:
-      - name: Set build environment variables
-        run: |
-          if [ "$BUILD_BITS" = "64" ]
-          then
-            echo BUILD_ARCH="rv64imafdc" >> $GITHUB_ENV
-            echo BUILD_ABI="lp64d" >> $GITHUB_ENV
-          elif [ "$BUILD_BITS" = "32" ]
-          then
-            echo BUILD_ARCH="rv32gc" >> $GITHUB_ENV
-            echo BUILD_ABI="ilp32d" >> $GITHUB_ENV
-          else
-            echo "Unsupported architecture: $BUILD_BITS bits"
-            exit 1
-          fi
-
-      - uses: actions/download-artifact@v2
-        with:
-          name: full-source
-      
-      # workaround https://github.com/actions/upload-artifact/issues/38
-      - name: tarball source
-        run: tar -xvf source.tar.gz
 
       - name: install apt dependencies
         run: sudo ./.github/setup-apt.sh
       
-      - name: Build Toolchain
+      - name: build toolchain
         run: |
-          ./configure --prefix=/opt/riscv --with-arch=${BUILD_ARCH} --with-abi=${BUILD_ABI}
-          sudo make -j $(nproc) linux
+          TARGET_TUPLE=($(echo ${{ matrix.target }} | tr "-" "\n"))
+          ./configure --prefix=/opt/riscv --with-arch=${TARGET_TUPLE[0]} --with-abi=${TARGET_TUPLE[1]}
+          sudo make -j $(nproc) ${{ matrix.mode }}
 
       - name: tarball build
         run: tar czvf riscv.tar.gz -C /opt/ riscv/
-      
+
+      - name: generate prebuilt toolchain name
+        id:   toolchain-name-generator
+        run: |
+          if [[ "${{ matrix.target }}" == *"32"* ]]; then BITS=32; else BITS=64; fi
+          if [[ "${{ matrix.mode }}" == "linux" ]]; then MODE="glibc"; else MODE="elf"; fi
+          echo ::set-output name=TOOLCHAIN_NAME::riscv$BITS-$MODE-${{ matrix.os }}-nightly
+
       - uses: actions/upload-artifact@v2
-        name: upload build as an artifact
         with:
-          name: riscv${{ matrix.bits }}-${{ matrix.os }}
+          name: ${{ steps.toolchain-name-generator.outputs.TOOLCHAIN_NAME }}
           path: riscv.tar.gz
 
 
   create-release:
-    needs: [ build-ubuntu ]
+    needs: build
     runs-on: ubuntu-latest
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}


### PR DESCRIPTION
GitHub action script, which automatically builds and uploads pre-built packages
- Runs daily, but only if there has been changes to the repo within the past 24 hours
- Example: https://github.com/kevinpark1217/riscv-gnu-toolchain/releases/tag/2021.01.23

Renames packaging.yaml to build.yaml
- Also runs if there is a pull request to master branch
- Can be used as an additional check to new pull requests
- Additional precompile process for rv32/64-elf toolchain: @higuoxing

Tested Here: https://github.com/kevinpark1217/riscv-gnu-toolchain/actions/runs/504980647

Related Issue: https://github.com/riscv/riscv-gnu-toolchain/issues/747#issuecomment-714298672