### PR TITLE
Use `git rev-parse` to find .git dir

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -245,8 +245,8 @@ endif
 
 $(srcdir)/%/.git:
 	cd $(srcdir) && \
-	flock $(srcdir)/.git/config git submodule init $(dir $@) && \
-	flock $(srcdir)/.git/config git submodule update $(dir $@)
+	flock `git rev-parse --git-dir`/config git submodule init $(dir $@) && \
+	flock `git rev-parse --git-dir`/config git submodule update $(dir $@)
 
 #
 # GLIBC


### PR DESCRIPTION
Otherwise, this code breaks if riscv-gnu-toolchain is itself a submodule of another project:
```
flock: cannot open lock file /other/repo/riscv-gnu-toolchain/.git/config: Not a directory
make[1]: *** [/other/repo/riscv-gnu-toolchain/riscv-gcc/.git] Error 66
```

In this case the git config for this tree is at `/other/repo/.git/modules/riscv-gnu-toolchain/config`.