### PR TITLE
Bump Binutils to 2.36.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "riscv-binutils"]
 	path = riscv-binutils
 	url = ../riscv-binutils-gdb.git
-	branch = riscv-binutils-2.35
+	branch = riscv-binutils-2.36.1
 [submodule "riscv-gcc"]
 	path = riscv-gcc
 	url = ../riscv-gcc.git


### PR DESCRIPTION
There is no particular reason for the bump (from my perspective), besides the desire to use the latest release versions.