### PR TITLE
gitignore build directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ config.status
 Makefile
 .DS_Store
 !/regression/Makefile
+/build-*/
+/install-newlib-nano/
+/stamps/


### PR DESCRIPTION
When I build this repo I get lots of directories that Git reports as untracked. I've added them to .gitignore here.

Is there a better way? I tried to move all these build directories to somewhere outside of the git root, but the Makefile doesn't seem to support that, and I'm not familiar enough with the flow here to add that capability.
