### PR TITLE
Bump gcc to 11.1

### DIFF
--- a/test/allowlist/gcc/common.log
+++ b/test/allowlist/gcc/common.log
@@ -1,8 +1,4 @@
 #
-# Upstream regression, PR 86153.
-#
-FAIL: g++.dg/pr83239.C
-#
 # Check for nop insns fails due to ".option nopic".
 #
 FAIL: c-c++-common/patchable_function_entry-decl.c
@@ -25,10 +21,6 @@ FAIL: gcc.dg/debug/dwarf2/inline5.c
 # We're optimizing something that shouldn't be optimized.
 #
 XPASS: gcc.dg/graphite/pr69728.c
-#
-# Upstream regression, PR 94853.
-#
-FAIL: gfortran.dg/analyzer/pr93993.f90
 #
 # Upstream regression, PR 90811.
 # Patch under review:

--- a/test/allowlist/gcc/glibc.log
+++ b/test/allowlist/gcc/glibc.log
@@ -12,7 +12,6 @@ FAIL: gcc.dg/cleanup-11.c
 #
 # XXX: Need review why.
 #
-FAIL: gfortran.dg/elemental_subroutine_3.f90
 FAIL: gfortran.dg/ieee/ieee_6.f90
 #
 # ieee_1.F90 is a QEMU bug: https://github.com/riscv/riscv-qemu/issues/64
@@ -22,3 +21,10 @@ FAIL: gfortran.dg/ieee/ieee_1.F90
 # Synchronization problem.
 #
 FAIL: gcc.dg/tree-prof/time-profiler-2.c
+#
+# TLS related testcase might random fail on qemu
+# But it's hard to reproduce and seems only happen on qemu.
+# So put those case here for now.
+#
+FAIL: g++.dg/tls/thread_local4.C
+FAIL: g++.dg/tls/thread_local4g.C

--- a/test/allowlist/gcc/glibc.rv32.log
+++ b/test/allowlist/gcc/glibc.rv32.log
@@ -1,2 +1,10 @@
 #
 FAIL: g++.dg/torture/pr86763.C
+#
+# It's new failed case since GCC 11,
+# this case only failed on -O0
+# But...I (Kito) don't know fortran too much,
+# so put this here for now until someday we have time to
+# investigating...
+#
+FAIL: gfortran.dg/assumed_rank_bounds_3.f90

--- a/test/allowlist/gcc/newlib.log
+++ b/test/allowlist/gcc/newlib.log
@@ -13,3 +13,12 @@ FAIL: gcc.c-torture/execute/printf-2.c
 # Missing dg-require-effective-target shared
 #
 FAIL: g++.dg/lto/pr87906 cp_lto_pr87906_0.o-cp_lto_pr87906_1.o link,  -O -fPIC -flto
+#
+# -lc not enough to link final executable for newlib.
+#
+FAIL: g++.dg/abi/pure-virtual1.C
+#
+# newlib header issue, `reent.h`has complication warning when compile
+# with `-Wall`
+#
+FAIL: g++.dg/warn/Wstringop-overflow-6.C


### PR DESCRIPTION
Passed regression run, and review all failed case.

New failed case:
- FAIL: g++.dg/warn/Wstringop-overflow-6.C
  - newlib header will got complication warning with `-Wall` for `reent.h` 
- FAIL: g++.dg/abi/pure-virtual1.C
  -  `-lc` not enough to link final executable for newlib.
- FAIL: gfortran.dg/assumed_rank_bounds_3.f90
  - It's new failed case since GCC 11, this case only failed on `-O0`, but...I (Kito) don't know fortran too much, so put this here for     now until someday we have time to investigating...