### PR TITLE
Add flock to OS X dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ On Arch Linux, executing the following command should suffice:
 On OS X, you can use [Homebrew](http://brew.sh) to install the dependencies:
 
     $ brew install python3 gawk gnu-sed gmp mpfr libmpc isl zlib expat
+    $ brew tap discoteq/discoteq
+    $ brew install flock
 
 To build the glibc (Linux) on OS X, you will need to build within a case-sensitive file
 system.  The simplest approach is to create and mount a new disk image with


### PR DESCRIPTION
I tried:

```
$ git clone https://github.com/riscv/riscv-gnu-toolchain
$ cd riscv-gnu-toolchain
$ ./configure --prefix=/usr/local/riscv-gnu-toolchain --with-cmodel=medany --enable-multilib
$ make
```

on Mac OS 10.15.7.

I got:
```
cd /Users/bradjc/git/riscv-gnu-toolchain && \
	flock `git rev-parse --git-dir`/config git submodule init /Users/bradjc/git/riscv-gnu-toolchain/riscv-gcc/ && \
	flock `git rev-parse --git-dir`/config git submodule update /Users/bradjc/git/riscv-gnu-toolchain/riscv-gcc/
/bin/sh: flock: command not found
make: *** [/Users/bradjc/git/riscv-gnu-toolchain/riscv-gcc/.git] Error 127
```

The proposed changes to the readme seem to fix it.