### PR TITLE
Add Submodule Caching to Toolchain Generation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,8 +9,81 @@ on:
       - master
 
 jobs:
+  cache:
+    name: Update Submodule Cache
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache GCC
+        uses: actions/cache@v4
+        with:
+          path: |
+            .git/modules/gcc
+            gcc
+          key: compiler-gcc
+
+      - name: Cache LLVM
+        uses: actions/cache@v4
+        with:
+          path: |
+            .git/modules/llvm
+            llvm
+          key: compiler-llvm
+      
+      - name: Cache Newlib
+        uses: actions/cache@v4
+        with:
+          path: |
+            .git/modules/newlib
+            newlib
+          key: mode-newlib
+
+      - name: Cache Linux
+        uses: actions/cache@v4
+        with:
+          path: |
+            .git/modules/glibc
+            glibc
+          key: mode-linux
+
+      - name: Cache musl
+        uses: actions/cache@v4
+        with:
+          path: |
+            .git/modules/musl
+            musl
+          key: mode-musl
+
+      - name: Cache uClibc
+        uses: actions/cache@v4
+        with:
+          path: |
+            .git/modules/uclibc-ng
+            uclibc-ng
+          key: mode-uclibc
+
+      - name: Cache Always Required Submodules
+        uses: actions/cache@v4
+        with:
+          path: |
+            .git/modules/binutils
+            .git/modules/gdb
+            binutils
+            gdb
+          key: general-dependencies
+
+      - name: Clone needed submodules
+        run: |
+          git submodule update --init --progress --depth 1 --jobs $(nproc) binutils gdb gcc llvm newlib glibc musl
+          git submodule update --init --progress uclibc-ng
+
+
+    
   build:
+    name: Build Toolchain Variants
     runs-on: ${{ matrix.os }}
+    needs: [cache]
     strategy:
       matrix:
         os:     [ubuntu-22.04, ubuntu-24.04]
@@ -32,12 +105,68 @@ jobs:
           echo "-- After --"
           df -h
 
+      - name: Generate Required Submodules
+        id: required-submodules
+        run: |
+          case "${{ matrix.mode }}" in
+            "linux")
+              MODE_SUBMODULE="glibc";;
+            "musl")
+              MODE_SUBMODULE="musl";;
+            "uclibc")
+              MODE_SUBMODULE="uclibc-ng";;
+            "newlib")
+              MODE_SUBMODULE="newlib";;
+            *)
+              echo "Invalid Mode"; exit 1;;
+          esac
+          echo "MODE_SUBMODULE=$MODE_SUBMODULE" >> $GITHUB_OUTPUT
+          case "${{ matrix.compiler }}" in
+            "gcc")
+              COMPILER_SUBMODULE="gcc";;
+            "llvm")
+              COMPILER_SUBMODULE="llvm";;
+            *)
+              echo "Invalid Compiler"; exit 1;;
+          esac
+          echo "COMPILER_SUBMODULE=$COMPILER_SUBMODULE" >> $GITHUB_OUTPUT
+
       - uses: actions/checkout@v4
 
-      - name: install dependencies
+      - name: Load Compiler Submodule from Cache
+        uses: actions/cache/restore@v4
+        env:
+          submodule: ${{ steps.required-submodules.outputs.COMPILER_SUBMODULE }}
+        with:
+          path: |
+            .git/modules/${{ env.submodule }}
+            ${{ env.submodule }}
+          key: compiler-${{ matrix.compiler }}
+
+      - name: Load Mode Submodule from Cache
+        uses: actions/cache/restore@v4
+        env:
+          submodule: ${{ steps.required-submodules.outputs.MODE_SUBMODULE }}
+        with:
+          path: |
+            .git/modules/${{ env.submodule }}
+            ${{ env.submodule }}
+          key: mode-${{ matrix.mode }}
+      
+      - name: Load Always Required Submodules from Cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            .git/modules/binutils
+            .git/modules/gdb
+            binutils
+            gdb
+          key: general-dependencies
+
+      - name: Install Dependencies
         run: sudo ./.github/setup-apt.sh
 
-      - name: build toolchain
+      - name: Build Toolchain
         run: |
           TARGET_TUPLE=($(echo ${{ matrix.target }} | tr "-" "\n"))
           BUILD_TOOLCHAIN="./configure --prefix=/opt/riscv --with-arch=${TARGET_TUPLE[0]} --with-abi=${TARGET_TUPLE[1]}"
@@ -48,7 +177,7 @@ jobs:
           fi
           sudo make -j $(nproc) ${{ matrix.mode }}
 
-      - name: make report
+      - name: Generate Report
         if: |
           matrix.os == 'ubuntu-24.04'
           && (matrix.mode == 'linux' || matrix.mode == 'newlib')
@@ -56,16 +185,16 @@ jobs:
         run: |
           sudo make report-${{ matrix.mode }} -j $(nproc)
 
-      - name: recover space
+      - name: Recover Space
         run: |
           sudo du -hs / 2> /dev/null || true
           sudo rm -rf binutils dejagnu gcc gdb glibc llvm musl newlib pk qemu spike uclibc-ng || true
           sudo du -hs / 2> /dev/null || true
 
-      - name: tarball build
+      - name: Tar Toolchain
         run: tar czvf riscv.tar.gz -C /opt/ riscv/
 
-      - name: generate prebuilt toolchain name
+      - name: Generate Prebuilt Toolchain Name
         id:   toolchain-name-generator
         run: |
           if [[ "${{ matrix.target }}" == *"32"* ]]; then BITS=32; else BITS=64; fi
@@ -87,6 +216,7 @@ jobs:
           path: riscv.tar.gz
 
   test-sim:
+    name: Test Simulation
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -106,16 +236,16 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: install dependencies
+      - name: Install Dependencies
         run: sudo ./.github/setup-apt.sh
 
-      - name: build toolchain
+      - name: Build Toolchain
         run: |
           TARGET_TUPLE=($(echo ${{ matrix.target }} | tr "-" "\n"))
           ./configure --prefix=/opt/riscv --with-arch=${TARGET_TUPLE[0]} --with-abi=${TARGET_TUPLE[1]} --with-sim=${{ matrix.sim }}
           make -j $(nproc) ${{ matrix.mode }}
 
-      - name: make report
+      - name: Generate Report
         run: make report-${{ matrix.mode }} -j $(nproc)
 
   build-multilib:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
         id: submodule-hash
         run: echo "HASH=$(git submodule | sha1sum | head -c 40)" >> $GITHUB_OUTPUT
 
-      - name: Check is Cache Exists for Exact Submodule Configuration
+      - name: Check if Cache Exists for Exact Submodule Configuration
         id: cache-check
         uses: actions/cache/restore@v4
         with:
@@ -31,7 +31,7 @@ jobs:
           key: submodules-${{ steps.submodule-hash.outputs.HASH }}
           lookup-only: true
 
-      - name: If no Cache Hit, Update Cache
+      - name: If Cache Misses, Update Cache
         uses: actions/cache@v4
         if: steps.cache-check.outputs.cache-hit != 'true'
         with:
@@ -40,11 +40,11 @@ jobs:
           restore-keys: |
             submodules-
 
-      - name: Clone submodules
+      - name: Clone Submodules
         if: steps.cache-check.outputs.cache-hit != 'true'
         run: |
-          git submodule update --init --progress --depth 1 --jobs $(nproc) binutils gdb gcc llvm newlib glibc musl dejagnu pk qemu spike
           git submodule update --init --progress uclibc-ng
+          git submodule update --init --progress --depth 1 --jobs $(nproc)
 
 
     
@@ -77,7 +77,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Load cache
+      - name: Restore Submodule Cache
         uses: actions/cache/restore@v4
         with:
           path: ${{ env.cache-path }}
@@ -159,7 +159,8 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: actions/cache/restore@v4
+      - name: Restore Submodule Cache
+        uses: actions/cache/restore@v4
         with:
           path: ${{ env.cache-path }}
           key: ${{ env.cache-key }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,18 +10,6 @@ on:
 env:
   cache-path: |
     .git/modules
-    binutils
-    gdb
-    gcc
-    llvm
-    newlib
-    glibc
-    musl
-    uclib-ng
-    dejagnu
-    pk
-    qemu
-    spike
 jobs:
   cache:
     name: Update Submodule Cache
@@ -87,44 +75,39 @@ jobs:
           echo "-- After --"
           df -h
 
-      - name: Generate Submodules List
+      - uses: actions/checkout@v4
+
+      - name: Load cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.cache-path }}
+          key: ${{ env.cache-key }}
+
+      - name: Restore submodules
         id: cache-path
-        if: false
         run: |
-          submodules="gdb:binutils"
+          submodules="gdb binutils"
           case "${{ matrix.mode }}" in
             "linux")
-              submodules="$submodules:glibc";;
+              submodules="$submodules glibc";;
             "musl")
-              submodules="$submodules:musl";;
+              submodules="$submodules musl";;
             "uclibc")
-              submodules="$submodules:uclibc-ng";;
+              submodules="$submodules uclibc-ng";;
             "newlib")
-              submodules="$submodules:newlib";;
+              submodules="$submodules newlib";;
             *)
               echo "Invalid Mode"; exit 1;;
           esac
           case "${{ matrix.compiler }}" in
             "gcc")
-              submodules="$submodules:gcc";;
+              submodules="$submodules gcc";;
             "llvm")
-              submodules="$submodules:llvm";;
+              submodules="$submodules llvm";;
             *)
               echo "Invalid Compiler"; exit 1;;
           esac
-          submodules=$(echo $submodules | sed 's/:/\n/g')
-          submodules=$submodules$'\n'$(echo "$submodules" | sed -e 's/^/.git\/modules\//')
-          echo 'submodules<<EOF' >> $GITHUB_OUTPUT
-          echo "$submodules" >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
-
-      - uses: actions/checkout@v4
-
-      - name: Load Cache
-        uses: actions/cache/restore@v4
-        with:
-          path: ${{ env.cache-path }}
-          key: ${{ env.cache-key }}
+          git submodule update --init $submodules
 
       - name: Install Dependencies
         run: sudo ./.github/setup-apt.sh
@@ -206,6 +189,9 @@ jobs:
         with:
           path: ${{ env.cache-path }}
           key: ${{ env.cache-key }}
+
+      - name: Restore submodules
+        run: git submodule update --init gcc newlib binutils gdb spike pk dejagnu
 
       - name: Install Dependencies
         run: sudo ./.github/setup-apt.sh

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,32 +83,6 @@ jobs:
           path: ${{ env.cache-path }}
           key: ${{ env.cache-key }}
 
-      - name: Restore submodules
-        id: cache-path
-        run: |
-          submodules="gdb binutils"
-          case "${{ matrix.mode }}" in
-            "linux")
-              submodules="$submodules glibc";;
-            "musl")
-              submodules="$submodules musl";;
-            "uclibc")
-              submodules="$submodules uclibc-ng";;
-            "newlib")
-              submodules="$submodules newlib";;
-            *)
-              echo "Invalid Mode"; exit 1;;
-          esac
-          case "${{ matrix.compiler }}" in
-            "gcc")
-              submodules="$submodules gcc";;
-            "llvm")
-              submodules="$submodules llvm";;
-            *)
-              echo "Invalid Compiler"; exit 1;;
-          esac
-          git submodule update --init $submodules
-
       - name: Install Dependencies
         run: sudo ./.github/setup-apt.sh
 
@@ -189,9 +163,6 @@ jobs:
         with:
           path: ${{ env.cache-path }}
           key: ${{ env.cache-key }}
-
-      - name: Restore submodules
-        run: git submodule update --init gcc newlib binutils gdb spike pk dejagnu
 
       - name: Install Dependencies
         run: sudo ./.github/setup-apt.sh

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,75 +7,55 @@ on:
   pull_request:
     branches:
       - master
-
+env:
+  cache-path: |
+    .git/modules
+    binutils
+    gdb
+    gcc
+    llvm
+    newlib
+    glibc
+    musl
+    uclib-ng
+    dejagnu
+    pk
+    qemu
+    spike
 jobs:
   cache:
     name: Update Submodule Cache
     runs-on: ubuntu-24.04
+    outputs:
+      key: submodules-${{ steps.submodule-hash.outputs.HASH }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache GCC
-        uses: actions/cache@v4
-        with:
-          path: |
-            .git/modules/gcc
-            gcc
-          key: compiler-gcc
+      - name: Generate Submodule Hash
+        id: submodule-hash
+        run: echo "HASH=$(git submodule | sha1sum | head -c 40)" >> $GITHUB_OUTPUT
 
-      - name: Cache LLVM
-        uses: actions/cache@v4
+      - name: Check is Cache Exists for Exact Submodule Configuration
+        id: cache-check
+        uses: actions/cache/restore@v4
         with:
-          path: |
-            .git/modules/llvm
-            llvm
-          key: compiler-llvm
-      
-      - name: Cache Newlib
-        uses: actions/cache@v4
-        with:
-          path: |
-            .git/modules/newlib
-            newlib
-          key: mode-newlib
+          path: ${{ env.cache-path }}
+          key: submodules-${{ steps.submodule-hash.outputs.HASH }}
+          lookup-only: true
 
-      - name: Cache Linux
+      - name: If no Cache Hit, Update Cache
         uses: actions/cache@v4
+        if: steps.cache-check.outputs.cache-hit != 'true'
         with:
-          path: |
-            .git/modules/glibc
-            glibc
-          key: mode-linux
+          path: ${{ env.cache-path }}
+          key: submodules-${{ steps.submodule-hash.outputs.HASH }}
+          restore-keys: |
+            submodules-
 
-      - name: Cache musl
-        uses: actions/cache@v4
-        with:
-          path: |
-            .git/modules/musl
-            musl
-          key: mode-musl
-
-      - name: Cache uClibc
-        uses: actions/cache@v4
-        with:
-          path: |
-            .git/modules/uclibc-ng
-            uclibc-ng
-          key: mode-uclibc
-
-      - name: Cache Always Required Submodules
-        uses: actions/cache@v4
-        with:
-          path: |
-            .git/modules/binutils
-            .git/modules/gdb
-            binutils
-            gdb
-          key: general-dependencies
-
-      - name: Clone needed submodules
+      - name: Clone submodules
+        if: steps.cache-check.outputs.cache-hit != 'true'
         run: |
-          git submodule update --init --progress --depth 1 --jobs $(nproc) binutils gdb gcc llvm newlib glibc musl
+          git submodule update --init --progress --depth 1 --jobs $(nproc) binutils gdb gcc llvm newlib glibc musl dejagnu pk qemu spike
           git submodule update --init --progress uclibc-ng
 
 
@@ -84,6 +64,8 @@ jobs:
     name: Build Toolchain Variants
     runs-on: ${{ matrix.os }}
     needs: [cache]
+    env:
+      cache-key: ${{ needs.cache.outputs.key }}
     strategy:
       matrix:
         os:     [ubuntu-22.04, ubuntu-24.04]
@@ -105,63 +87,44 @@ jobs:
           echo "-- After --"
           df -h
 
-      - name: Generate Required Submodules
-        id: required-submodules
+      - name: Generate Submodules List
+        id: cache-path
+        if: false
         run: |
+          submodules="gdb:binutils"
           case "${{ matrix.mode }}" in
             "linux")
-              MODE_SUBMODULE="glibc";;
+              submodules="$submodules:glibc";;
             "musl")
-              MODE_SUBMODULE="musl";;
+              submodules="$submodules:musl";;
             "uclibc")
-              MODE_SUBMODULE="uclibc-ng";;
+              submodules="$submodules:uclibc-ng";;
             "newlib")
-              MODE_SUBMODULE="newlib";;
+              submodules="$submodules:newlib";;
             *)
               echo "Invalid Mode"; exit 1;;
           esac
-          echo "MODE_SUBMODULE=$MODE_SUBMODULE" >> $GITHUB_OUTPUT
           case "${{ matrix.compiler }}" in
             "gcc")
-              COMPILER_SUBMODULE="gcc";;
+              submodules="$submodules:gcc";;
             "llvm")
-              COMPILER_SUBMODULE="llvm";;
+              submodules="$submodules:llvm";;
             *)
               echo "Invalid Compiler"; exit 1;;
           esac
-          echo "COMPILER_SUBMODULE=$COMPILER_SUBMODULE" >> $GITHUB_OUTPUT
+          submodules=$(echo $submodules | sed 's/:/\n/g')
+          submodules=$submodules$'\n'$(echo "$submodules" | sed -e 's/^/.git\/modules\//')
+          echo 'submodules<<EOF' >> $GITHUB_OUTPUT
+          echo "$submodules" >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@v4
 
-      - name: Load Compiler Submodule from Cache
-        uses: actions/cache/restore@v4
-        env:
-          submodule: ${{ steps.required-submodules.outputs.COMPILER_SUBMODULE }}
-        with:
-          path: |
-            .git/modules/${{ env.submodule }}
-            ${{ env.submodule }}
-          key: compiler-${{ matrix.compiler }}
-
-      - name: Load Mode Submodule from Cache
-        uses: actions/cache/restore@v4
-        env:
-          submodule: ${{ steps.required-submodules.outputs.MODE_SUBMODULE }}
-        with:
-          path: |
-            .git/modules/${{ env.submodule }}
-            ${{ env.submodule }}
-          key: mode-${{ matrix.mode }}
-      
-      - name: Load Always Required Submodules from Cache
+      - name: Load Cache
         uses: actions/cache/restore@v4
         with:
-          path: |
-            .git/modules/binutils
-            .git/modules/gdb
-            binutils
-            gdb
-          key: general-dependencies
+          path: ${{ env.cache-path }}
+          key: ${{ env.cache-key }}
 
       - name: Install Dependencies
         run: sudo ./.github/setup-apt.sh
@@ -218,6 +181,9 @@ jobs:
   test-sim:
     name: Test Simulation
     runs-on: ${{ matrix.os }}
+    needs: [cache]
+    env:
+      cache-key: ${{ needs.cache.outputs.key }}
     strategy:
       matrix:
         os:     [ubuntu-24.04]
@@ -235,6 +201,11 @@ jobs:
           df -h
 
       - uses: actions/checkout@v4
+
+      - uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.cache-path }}
+          key: ${{ env.cache-key }}
 
       - name: Install Dependencies
         run: sudo ./.github/setup-apt.sh


### PR DESCRIPTION
Adds a job at the beginning of the build workflow which updates caches containing the different submodules required to build the different variants.

This job takes about 3 minutes to run the first time, and after that it takes about 4 seconds to check that the cache is still up to date. This could also be moved to a different trigger which runs less often.

This greatly reduces the amount of resources used to clone submodules (just for the build variants for now). The clones that do happen are shallow (except for uclibc-ng) which also shrinks the git overhead by at least 1GB.

This action only caches the `.git/modules` directory as the rest of the working directory can be rebuilt from those without needing to download anything else. This allows us to choose which submodules we want to manifest into our build environment. The directory sizes for GCC and LLVM are 1.1GB and 1.9GB respectively, so being able to pick which we want in our environment saves a lot of disk space.

An additional note on github caches. They are scoped to branches, but any branch can restore a cache that was saved by `master`. Repos are limited to 10GB of total cache storage, so restricting cache generation to `master` may also be a good move to prevent using all of the cache storage capacity.