### PR TITLE
Install qemu TCG plugins to ${INSTALL_DIR}/lib/qemu/plugins

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1128,6 +1128,9 @@ stamps/build-qemu: $(QEMU_SRCDIR) $(QEMU_SRC_GIT) $(PREPARATION_STAMP)
 		--python=python3
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) install
+	mkdir -p $(INSTALL_DIR)/lib/qemu/plugins
+	cp $(notdir $@)/contrib/plugins/*.$(SHARED_LIB_SUFFIX) $(INSTALL_DIR)/lib/qemu/plugins
+	cp $(notdir $@)/tests/tcg/plugins/*.$(SHARED_LIB_SUFFIX) $(INSTALL_DIR)/lib/qemu/plugins
 	mkdir -p $(dir $@)
 	date > $@
 


### PR DESCRIPTION
So that we can use some plugins to do profiling. For example, use
`libinsn.so` to count dynamic instructions.
