### PR TITLE
Added Dockerfile V1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# Docker to build
+FROM ubuntu:22.04 AS builder
+
+RUN apt-get update && apt-get install -y autoconf automake autotools-dev curl python3 python3-pip python3-tomli libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ninja-build git cmake libglib2.0-dev libslirp-dev
+
+RUN mkdir -p /home/app
+
+WORKDIR /home/app
+
+RUN git clone https://github.com/riscv-collab/riscv-gnu-toolchain.git
+
+WORKDIR /home/app/riscv-gnu-toolchain
+RUN git checkout 2025.01.20
+RUN sed -i '/shallow = true/d' .gitmodules
+RUN sed -i 's/--depth 1//g' Makefile.in
+RUN ./configure --prefix=/opt/riscv --with-arch=rv64gc --with-abi=lp64d
+RUN make linux -j 4
+
+# Clean
+#RUN rm -rf /home/app
+
+
+# Final docker
+FROM ubuntu:22.04
+
+RUN apt-get update && apt-get install -y autoconf automake autotools-dev curl python3 python3-pip python3-tomli libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ninja-build git cmake libglib2.0-dev libslirp-dev
+
+COPY --from=builder /opt/ /opt/
+
+ENV PATH="$PATH:/opt/riscv/bin"
+
+


### PR DESCRIPTION
Good morning.

A few days ago I opened an issue due to a compilation problem in a cluster where I could not install the dependencies with apt-get.

Due to this problem I thought to make a docker container and compile inside the toolchain. I think it is interesting to add it to the repository and update it with the versions.

I think it would be interesting that when a new release of the toolchain is released, a container is left in DockerHub with the compiled toolchain.

To test it I compiled it with the options:

`./configure --prefix=/opt/riscv --with-arch=rv64gc --with-abi=lp64d`

Since different architectures and ABIs are supported, maybe an option to make the container more generic is to compile for several architectures and ABIs using “--with-multilib-generator=”. (I didn't test this option, but I think that's what it refers to).

To build the image, just have docker installed and run in the directory where the Dockerfile is the command:

`docker build -t riscv-gnu-toolchain:2025.01.20_rv64gc_lp64d .`

where before the colon (`riscv-gnu-toolchain`) is the name of the image and after (`2025.01.20_rv64gc_lp64d`) is the tag of the image.

Once you have the image, you only have to lift the container with the command

`docker run --name riscv-gnu-toolchain -id riscv-gnu-toolchain:2025.01.20_rv64gc_lp64d bash`

and run:

`docker exec riscv64-unknown-linux-gnu-gcc -v`

To run in HPC environment (clusters), you have to convert the image to singularity.

I look forward to your comments,
David