### PR TITLE
Makefile.in: Cleaning up the clean targets

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1360,7 +1360,7 @@ report-binutils-linux: stamps/check-binutils-linux
 	    `find build-binutils-linux/ -name *.sum |paste -sd "," -`
 
 clean:
-	rm -rf build-* install-* stamps install-newlib-nano
+	rm -rf build-* install-* stamps
 
 .PHONY: report-gdb-newlib report-gdb-newlib-nano
 report-gdb-newlib: stamps/check-gdb-newlib
@@ -1383,7 +1383,6 @@ report-gdb-linux: stamps/check-gdb-linux
 	if find build-gdb-linux -iname '*.sum' | xargs grep ^FAIL | sort | grep -F -v $(patsubst %,--file=$(srcdir)/test/gdb-linux/%.log,$(GLIBC_MULTILIB_NAMES)); then false; else true; fi
 
 distclean: clean
-	rm -rf src
 
 # All of the packages install themselves, so our install target does nothing.
 install:


### PR DESCRIPTION
The `clean` target removes `install-*` and `install-newlib-nano`. Let's avoid the duplication.

The `distclean` target removes `src`, which does not exist. Let's drop this.