### PR TITLE
march-to-cpu-opt: Add zvfh and zvfhmin

### DIFF
--- a/scripts/march-to-cpu-opt
+++ b/scripts/march-to-cpu-opt
@@ -20,6 +20,8 @@ QEMU_EXT_OPTS = {
   "zhinx":           "zhinx=true",
   "zfinx":           "zfinx=true",
   "zdinx":           "zdinx=true",
+  "zvfh":            "zvfh=true",
+  "zvfhmin":         "zvfhmin=true",
 }
 
 SPIKE_EXT_NOT_ALLOWED = [


### PR DESCRIPTION
Add zvfh and zvfhmin to the list of ISA extension supported by QEMU.