### PR TITLE
regression: Smart construction/configuration of `TARGETS`

### DIFF
--- a/regression/Makefile
+++ b/regression/Makefile
@@ -2,33 +2,22 @@
 report:
 
 # The list of target tuples that we want to test.
-TARGETS  =
-TARGETS += newlib-rv32i-ilp32-medlow
-TARGETS += newlib-rv32im-ilp32-medlow
-TARGETS += newlib-rv32iac-ilp32-medlow
-TARGETS += newlib-rv32imac-ilp32-medlow
-TARGETS += newlib-rv32imafc-ilp32f-medlow
-TARGETS += newlib-rv64imac-lp64-medlow
-TARGETS += newlib-rv64imafdc-lp64d-medlow
-TARGETS += linux-rv32imac-ilp32-medlow
-TARGETS += linux-rv32imafdc-ilp32-medlow
-TARGETS += linux-rv32imafdc-ilp32d-medlow
-TARGETS += linux-rv64imac-lp64-medlow
-TARGETS += linux-rv64imafdc-lp64-medlow
-TARGETS += linux-rv64imafdc-lp64d-medlow
-TARGETS += newlib-rv32i-ilp32-medany
-TARGETS += newlib-rv32im-ilp32-medany
-TARGETS += newlib-rv32iac-ilp32-medany
-TARGETS += newlib-rv32imac-ilp32-medany
-TARGETS += newlib-rv32imafc-ilp32f-medany
-TARGETS += newlib-rv64imac-lp64-medany
-TARGETS += newlib-rv64imafdc-lp64d-medany
-TARGETS += linux-rv32imac-ilp32-medany
-TARGETS += linux-rv32imafdc-ilp32-medany
-TARGETS += linux-rv32imafdc-ilp32d-medany
-TARGETS += linux-rv64imac-lp64-medany
-TARGETS += linux-rv64imafdc-lp64-medany
-TARGETS += linux-rv64imafdc-lp64d-medany
+TARGET_BASES = \
+	newlib-rv32i-ilp32      \
+	newlib-rv32im-ilp32     \
+	newlib-rv32iac-ilp32    \
+	newlib-rv32imac-ilp32   \
+	newlib-rv32imafc-ilp32f \
+	newlib-rv64imac-lp64    \
+	newlib-rv64imafdc-lp64d \
+	linux-rv32imac-ilp32    \
+	linux-rv32imafdc-ilp32  \
+	linux-rv32imafdc-ilp32d \
+	linux-rv64imac-lp64     \
+	linux-rv64imafdc-lp64   \
+	linux-rv64imafdc-lp64d
+TARGET_CODE_MODELS = medlow medany
+TARGETS ?= $(foreach CODE_MODEL,$(TARGET_CODE_MODELS), $(addsuffix -$(CODE_MODEL),$(TARGET_BASES)))
 
 # This is the link between the report targets and the actual testsuite
 # build/test runs.  It's setup with a level of indirection here to make sure


### PR DESCRIPTION
It makes:

1.  Default target list is easier to read and to reconfigure by splitting target bases and code models.
2.  `TARGETS` is now configurable through external environment variable (not just as a make argument), which makes `TARGETS` consistent with `RUNTESTFLAGS`.

Because `TARGETS = ...` is used inside the Makefile, we could configure targets to perform regression tests with `make report TARGETS='...'` but not `TARGETS='...' make report`.  This semantics is inconsistent with e.g. RUNTESTFLAGS as shown in README.md.

This commit now uses `?=` to respect environment variable `TARGETS` given from outside, making `TARGETS='...' make report` usable.

Also, this commit changes how default target list is constructed.
It splits target bases and code models and each is reconfigurable through make arguments (like `make report TARGET_CODE_MODELS=medlow`).
Note that `TARGET_BASES` and `TARGET_CODE_MODELS` are chosen so that no submodules use those Make variables and are ignored when the variable `TARGETS` is explicitly configured.