### PR TITLE
create option for enable or disable make-report in CI

### DIFF
--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -30,6 +30,10 @@ on:
         description: "Languages list"
         type: string
         default: '[""]'
+      report:
+        description: "Generate build report"
+        type: boolean
+        default: true
       sim:
         description: "Simulator"
         type: string
@@ -63,6 +67,7 @@ jobs:
           echo "Target list:    ${{ inputs.target }}"
           echo "Compiler list:  ${{ inputs.compiler }}"
           echo "C model list:   ${{ inputs.cmodel }}"
+          echo "Report:         ${{ inputs.report }}"
           echo "Languages list: ${{ inputs.languages }}"
           echo "Simulator:      ${{ inputs.sim }}"
 
@@ -111,6 +116,8 @@ jobs:
         sim: ${{ fromJSON(inputs.sim) }}
         cmodel: ${{ fromJSON(inputs.cmodel) }}
         languages: ${{ fromJSON(inputs.languages) }}
+        report: 
+          - ${{ inputs.report }}
 
         exclude:
           - mode: musl
@@ -167,6 +174,7 @@ jobs:
           matrix.os == 'ubuntu-24.04'
           && (matrix.mode == 'linux' || matrix.mode == 'newlib')
           && matrix.compiler == 'gcc'
+          && matrix.report == true
         run: |
           make report-${{ matrix.mode }} -j $(nproc)
 


### PR DESCRIPTION
As discussed with @cmuellner [here](https://github.com/riscv-collab/riscv-gnu-toolchain/issues/1778#issuecomment-3480545795).

As requested by @cmuellner , the default remains `report: true`, so the default behaviour is unchanged. Only if someone explicitly passes `report: false` to the CI will it change behaviour, by disabling the report.