### PR TITLE
limit strip option to just ELF files

### DIFF
--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -221,7 +221,18 @@ jobs:
           mv riscv.tar.xz ${{ steps.toolchain-name-generator.outputs.TOOLCHAIN_NAME }}.tar.xz
       - name: strip binaries
         run: |
-          find /mnt/riscv -type f -exec strip {} \;
+          # Strip all ELF binaries in the toolchain
+          # finds all of the files in /mnt/riscv, checks if they are ELF files, and strips them
+          # strip itself would be fine running on any files, it will just complain if they are
+          # not valid binaries. But that would capture the `.a` archives as well,
+          # which we do not want to strip. Doing so would make linking them later problematic.
+          # The logic:
+          # 1. Find all files under /mnt/riscv
+          # 2. For each file, run `file` command to check its type
+          # 3. If the output of `file` contains "ELF", it is an ELF binary
+          # 4. Strip that file
+          # 5. Ignore others
+          find /mnt/riscv -type f -exec sh -c 'file "$1" | grep -q "ELF" && strip "$1"' _ {} \;
       - name: tarball build stripped
         if: ${{ inputs.strip == 'stripped' || inputs.strip == 'both' }}
         run: |


### PR DESCRIPTION
The previous PR #1801 created an option in CI for releasing stripped or unstripped binaries (or both). While it works correctly, it also strips `.a` files, which can create problems when linking. 

This PR updates the strip command, so it only strips ELF files.