### PR TITLE
Add ncurses build dependency

### DIFF
--- a/.github/setup-apt.sh
+++ b/.github/setup-apt.sh
@@ -2,7 +2,9 @@
 
 # install OS prerequisites
 apt update
-apt install -y autoconf automake autotools-dev curl python3 python3-pip python3-tomli libmpc-dev libmpfr-dev \
-            libgmp-dev gawk build-essential bison flex texinfo gperf libtool \
-            patchutils bc zlib1g-dev libexpat-dev git ninja-build cmake libglib2.0-dev expect \
-            device-tree-compiler python3-pyelftools libslirp-dev libzstd-dev
+apt install -y autoconf automake autotools-dev curl python3 python3-pip \
+            python3-tomli libmpc-dev libmpfr-dev libgmp-dev gawk \
+            build-essential bison flex texinfo gperf libtool patchutils bc \
+            zlib1g-dev libexpat-dev git ninja-build cmake libglib2.0-dev \
+            expect device-tree-compiler python3-pyelftools libslirp-dev \
+            libzstd-dev libncurses-dev

--- a/README.md
+++ b/README.md
@@ -20,21 +20,21 @@ Several standard packages are needed to build the toolchain.
 
 On Ubuntu, executing the following command should suffice:
 
-    $ sudo apt-get install autoconf automake autotools-dev curl python3 python3-pip python3-tomli libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ninja-build git cmake libglib2.0-dev libslirp-dev
+    $ sudo apt-get install autoconf automake autotools-dev curl python3 python3-pip python3-tomli libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ninja-build git cmake libglib2.0-dev libslirp-dev libncurses-dev
 
 On Fedora/CentOS/RHEL OS, executing the following command should suffice:
 
-    $ sudo yum install autoconf automake python3 libmpc-devel mpfr-devel gmp-devel gawk  bison flex texinfo patchutils gcc gcc-c++ zlib-devel expat-devel libslirp-devel
+    $ sudo yum install autoconf automake python3 libmpc-devel mpfr-devel gmp-devel gawk  bison flex texinfo patchutils gcc gcc-c++ zlib-devel expat-devel libslirp-devel ncurses-devel
 
 On Arch Linux, executing the following command should suffice:
 
-    $ sudo pacman -Syu curl python3 libmpc mpfr gmp base-devel texinfo gperf patchutils bc zlib expat libslirp
+    $ sudo pacman -Syu curl python3 libmpc mpfr gmp base-devel texinfo gperf patchutils bc zlib expat libslirp ncurses
 
 Also available for Arch users on the AUR: [https://aur.archlinux.org/packages/riscv-gnu-toolchain-bin](https://aur.archlinux.org/packages/riscv-gnu-toolchain-bin)
 
 On macOS, you can use [Homebrew](http://brew.sh) to install the dependencies:
 
-    $ brew install python3 gawk gnu-sed make gmp mpfr libmpc isl zlib expat texinfo flock libslirp
+    $ brew install python3 gawk gnu-sed make gmp mpfr libmpc isl zlib expat texinfo flock libslirp ncurses
 
 When executing the instructions in this README, please use `gmake` instead of `make` to use the newly installed version of make.
 To build the glibc (Linux) on macOS, you will need to build within a case-sensitive file


### PR DESCRIPTION
Added in Github workflow and README.
GDB needs it to enable the TUI mode.

The build workflow has been tested and it works fine.

Added build requisites for Ubuntu/Debian, Fedora, Arch and MacOS in the README. Only Ubuntu have been tested. The correct package names for Fedora, Arch and MacOS have been searched on the Internet and should be right, but not tested since I do not have access to those systems. 