### PR TITLE
Fix --with-languages conf option in workflow

### DIFF
--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -133,7 +133,7 @@ jobs:
         sim: ${{ fromJSON(inputs.sim) }}
         cmodel: ${{ fromJSON(inputs.cmodel) }}
         languages: ${{ fromJSON(inputs.languages) }}
-        report: 
+        report:
           - ${{ inputs.report }}
 
         exclude:
@@ -173,7 +173,7 @@ jobs:
             ARGS="$ARGS --with-cmodel=${{ matrix.cmodel }}"
           fi
           if [ -n "${{ matrix.languages }}" ]; then
-            ARGS="$ARGS --enable-languages=${{ matrix.languages }}"
+            ARGS="$ARGS --with-languages=${{ matrix.languages }}"
           fi
           if [ "${{ matrix.strip }}" = "true" ]; then
             ARGS="$ARGS --enable-strip"


### PR DESCRIPTION
There is a typo in the workflow configuration. ./configure option --enable-languages should be --with-languages. It makes the language selection in the workflow not to work and always build the three compilers: c, c++ and fortran.

This PR fixes it.