### PR TITLE
Workflow option to build simulator

### DIFF
--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -42,6 +42,10 @@ on:
         description: "Simulator"
         type: string
         default: '[""]'
+      build-sim:
+        description: "Build simulator and include in the toolchain"
+        type: boolean
+        default: false
 
 env:
   submodule_paths: |
@@ -135,6 +139,8 @@ jobs:
         languages: ${{ fromJSON(inputs.languages) }}
         report:
           - ${{ inputs.report }}
+        build-sim:
+          - ${{ inputs.build-sim }}
 
         exclude:
           - mode: musl
@@ -182,6 +188,11 @@ jobs:
           sudo mkdir /mnt/riscv
           sudo chown runner:runner /mnt/riscv
           make -j $(nproc) ${{ matrix.mode }}
+      - name: build simulator
+        if: |
+          matrix.build-sim == true
+        run: |
+          make -j $(nproc) build-sim
       - name: make report
         if: |
           matrix.os == 'ubuntu-24.04'


### PR DESCRIPTION
The 'sim' option in the build-reusable.yalm workflow selects the simulator to be used, but it is only built if needed by dependencies in the Makefile (as with the 'report' step in the WF). The new option 'build-sim', when 'true', will build the simulator selected by 'sim' unconditionally by doing a 'make build-sim' as part of the toolchain build. The condition defaults to 'false' to keep the current behavior of the WF.