### PR TITLE
Copy libunwind to sysroot for LLVM Linux toolchain

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1213,6 +1213,7 @@ stamps/build-llvm-linux: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) $(BINUTILS_SRCDIR) $(BIN
 	    $(MAKE) -C $(notdir $@)/openmp-static install; \
 	fi
 	cp $(notdir $@)/lib/riscv$(XLEN)-unknown-linux-gnu/libc++* $(SYSROOT)/lib
+	cp $(notdir $@)/lib/riscv$(XLEN)-unknown-linux-gnu/libunwind* $(SYSROOT)/lib
 	cd $(INSTALL_DIR)/bin && ln -s -f clang $(LINUX_TUPLE)-clang && ln -s -f clang++ $(LINUX_TUPLE)-clang++
 	mkdir -p $(dir $@) && touch $@
 


### PR DESCRIPTION
The LLVM Linux toolchain build includes libunwind as a runtime, but the resulting libraries are not copied to the sysroot. This causes runtime issues when executables need libunwind.so.1.

Adds a cp command for libunwind files, matching the existing pattern used for libc++.

Fixes #1714.