### PR TITLE
Switch from bminor repositories to upstream repositories

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
-# Some of the external git repos are not upstream servers but upstream clones to
-# avoid "Server does not allow request for unadvertised object" errors (see
-# #1654).
 [submodule "binutils"]
 	path = binutils
-	url = https://github.com/bminor/binutils-gdb.git
+	url = https://sourceware.org/git/binutils-gdb.git
 	branch = binutils-2_45-branch
 	shallow = true
 [submodule "gcc"]
@@ -13,7 +10,7 @@
 	shallow = true
 [submodule "glibc"]
 	path = glibc
-	url = https://github.com/bminor/glibc.git
+	url = https://sourceware.org/git/glibc.git
 	shallow = true
 [submodule "dejagnu"]
 	path = dejagnu
@@ -22,12 +19,12 @@
 	shallow = true
 [submodule "newlib"]
 	path = newlib
-	url = https://github.com/bminor/newlib.git
+	url = https://sourceware.org/git/newlib-cygwin.git
 	branch = master
 	shallow = true
 [submodule "gdb"]
 	path = gdb
-	url = https://github.com/bminor/binutils-gdb.git
+	url = https://sourceware.org/git/binutils-gdb.git
 	branch = gdb-16-branch
 	shallow = true
 [submodule "qemu"]


### PR DESCRIPTION
The bminor/* repositories on GitHub are not available anymore, so we have to switch back to upstream servers.
Note, that this will re-introduce the cloning errors with the message "Server does not allow request for unadvertised object".

This reverts commit 400789aee30cb4c0e10e64029ceb93554c0a28f0.

See also #1828.