### PR TITLE
CI: Enable musl+llvm build in matrix

### DIFF
--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -143,8 +143,6 @@ jobs:
           - ${{ inputs.build-sim }}
 
         exclude:
-          - mode: musl
-            compiler: llvm
           - mode: uclibc
             compiler: llvm
     outputs:


### PR DESCRIPTION
musl llvm build support was added in dec5b17, remove the exclude entry that was blocking the musl+llvm combination.