### PR TITLE
GCC: Bump to latest commit on gcc-15 release branch

### DIFF
--- a/test/allowlist/gcc/rv32.log
+++ b/test/allowlist/gcc/rv32.log
@@ -6,3 +6,74 @@ FAIL: gcc.dg/torture/pr113026-1.c
 FAIL: gcc.dg/pr90838-2.c
 UNRESOLVED: gcc.target/riscv/pr116715.c
 FAIL: gcc.target/riscv/rvv/autovec/vls-vlmax/shuffle-slide.c
+#
+# TODO: Need review (regressions found after updating GCC 15 to a later
+#       commit on the release branch).
+#
+FAIL: g++.target/riscv/rvv/base/pr122448.C (test for excess errors)
+UNRESOLVED: g++.target/riscv/rvv/base/pr122448.C compilation failed to produce executable
+FAIL: g++.target/riscv/rvv/base/pr123808-2.C (internal compiler error: in extract_insn, at recog.cc:2882)
+FAIL: g++.target/riscv/rvv/base/pr123808-2.C (test for excess errors)
+UNRESOLVED: g++.target/riscv/rvv/base/pr123808-2.C compilation failed to produce executable
+FAIL: g++.target/riscv/rvv/base/pr123808.C (internal compiler error: in extract_insn, at recog.cc:2882)
+FAIL: g++.target/riscv/rvv/base/pr123808.C (test for excess errors)
+UNRESOLVED: g++.target/riscv/rvv/base/pr123808.C compilation failed to produce executable
+FAIL: gcc.dg/pr122991.c (internal compiler error: in expand_reversed_crc_table_based, at expr.cc:14670)
+FAIL: gcc.dg/pr122991.c (test for excess errors)
+FAIL: gcc.target/riscv/sat/sat_u_trunc-1-u16.c -O2  check-function-bodies sat_u_trunc_uint32_t_to_uint16_t_fmt_1
+FAIL: gcc.target/riscv/sat/sat_u_trunc-1-u16.c -O3  check-function-bodies sat_u_trunc_uint32_t_to_uint16_t_fmt_1
+FAIL: gcc.target/riscv/sat/sat_u_trunc-1-u16.c -Ofast  check-function-bodies sat_u_trunc_uint32_t_to_uint16_t_fmt_1
+FAIL: gcc.target/riscv/sat/sat_u_trunc-1-u16.c -Os  check-function-bodies sat_u_trunc_uint32_t_to_uint16_t_fmt_1
+FAIL: gcc.target/riscv/sat/sat_u_trunc-1-u16.c -Oz  check-function-bodies sat_u_trunc_uint32_t_to_uint16_t_fmt_1
+FAIL: gcc.target/riscv/sat/sat_u_trunc-1-u64.c -O2  check-function-bodies sat_u_trunc_uint32_t_to_uint8_t_fmt_1
+FAIL: gcc.target/riscv/sat/sat_u_trunc-1-u64.c -O3  check-function-bodies sat_u_trunc_uint32_t_to_uint8_t_fmt_1
+FAIL: gcc.target/riscv/sat/sat_u_trunc-1-u64.c -Ofast  check-function-bodies sat_u_trunc_uint32_t_to_uint8_t_fmt_1
+FAIL: gcc.target/riscv/sat/sat_u_trunc-1-u64.c -Os  check-function-bodies sat_u_trunc_uint32_t_to_uint8_t_fmt_1
+FAIL: gcc.target/riscv/sat/sat_u_trunc-1-u64.c -Oz  check-function-bodies sat_u_trunc_uint32_t_to_uint8_t_fmt_1
+FAIL: gcc.target/riscv/sat/sat_u_trunc-2-u64.c -O2  check-function-bodies sat_u_trunc_uint32_t_to_uint16_t_fmt_2
+FAIL: gcc.target/riscv/sat/sat_u_trunc-2-u64.c -O3  check-function-bodies sat_u_trunc_uint32_t_to_uint16_t_fmt_2
+FAIL: gcc.target/riscv/sat/sat_u_trunc-2-u64.c -Ofast  check-function-bodies sat_u_trunc_uint32_t_to_uint16_t_fmt_2
+FAIL: gcc.target/riscv/sat/sat_u_trunc-2-u64.c -Os  check-function-bodies sat_u_trunc_uint32_t_to_uint16_t_fmt_2
+FAIL: gcc.target/riscv/sat/sat_u_trunc-2-u64.c -Oz  check-function-bodies sat_u_trunc_uint32_t_to_uint16_t_fmt_2
+FAIL: gcc.target/riscv/sat/sat_u_trunc-3-u16.c -O2  check-function-bodies sat_u_trunc_uint32_t_to_uint8_t_fmt_2
+FAIL: gcc.target/riscv/sat/sat_u_trunc-3-u16.c -O3  check-function-bodies sat_u_trunc_uint32_t_to_uint8_t_fmt_2
+FAIL: gcc.target/riscv/sat/sat_u_trunc-3-u16.c -Ofast  check-function-bodies sat_u_trunc_uint32_t_to_uint8_t_fmt_2
+FAIL: gcc.target/riscv/sat/sat_u_trunc-3-u16.c -Os  check-function-bodies sat_u_trunc_uint32_t_to_uint8_t_fmt_2
+FAIL: gcc.target/riscv/sat/sat_u_trunc-3-u16.c -Oz  check-function-bodies sat_u_trunc_uint32_t_to_uint8_t_fmt_2
+FAIL: gcc.target/riscv/sat/sat_u_trunc-4-u16.c -O2  check-function-bodies sat_u_trunc_uint32_t_to_uint16_t_fmt_3
+FAIL: gcc.target/riscv/sat/sat_u_trunc-4-u16.c -O3  check-function-bodies sat_u_trunc_uint32_t_to_uint16_t_fmt_3
+FAIL: gcc.target/riscv/sat/sat_u_trunc-4-u16.c -Ofast  check-function-bodies sat_u_trunc_uint32_t_to_uint16_t_fmt_3
+FAIL: gcc.target/riscv/sat/sat_u_trunc-4-u16.c -Os  check-function-bodies sat_u_trunc_uint32_t_to_uint16_t_fmt_3
+FAIL: gcc.target/riscv/sat/sat_u_trunc-4-u16.c -Oz  check-function-bodies sat_u_trunc_uint32_t_to_uint16_t_fmt_3
+FAIL: gcc.target/riscv/sat/sat_u_trunc-4-u64.c -O2  check-function-bodies sat_u_trunc_uint32_t_to_uint8_t_fmt_3
+FAIL: gcc.target/riscv/sat/sat_u_trunc-4-u64.c -O3  check-function-bodies sat_u_trunc_uint32_t_to_uint8_t_fmt_3
+FAIL: gcc.target/riscv/sat/sat_u_trunc-4-u64.c -Ofast  check-function-bodies sat_u_trunc_uint32_t_to_uint8_t_fmt_3
+FAIL: gcc.target/riscv/sat/sat_u_trunc-4-u64.c -Os  check-function-bodies sat_u_trunc_uint32_t_to_uint8_t_fmt_3
+FAIL: gcc.target/riscv/sat/sat_u_trunc-4-u64.c -Oz  check-function-bodies sat_u_trunc_uint32_t_to_uint8_t_fmt_3
+FAIL: gcc.target/riscv/sat/sat_u_trunc-5-u64.c -O2  check-function-bodies sat_u_trunc_uint32_t_to_uint16_t_fmt_4
+FAIL: gcc.target/riscv/sat/sat_u_trunc-5-u64.c -O3  check-function-bodies sat_u_trunc_uint32_t_to_uint16_t_fmt_4
+FAIL: gcc.target/riscv/sat/sat_u_trunc-5-u64.c -Ofast  check-function-bodies sat_u_trunc_uint32_t_to_uint16_t_fmt_4
+FAIL: gcc.target/riscv/sat/sat_u_trunc-5-u64.c -Os  check-function-bodies sat_u_trunc_uint32_t_to_uint16_t_fmt_4
+FAIL: gcc.target/riscv/sat/sat_u_trunc-5-u64.c -Oz  check-function-bodies sat_u_trunc_uint32_t_to_uint16_t_fmt_4
+FAIL: gcc.target/riscv/sat/sat_u_trunc-6-u16.c -O2  check-function-bodies sat_u_trunc_uint32_t_to_uint8_t_fmt_4
+FAIL: gcc.target/riscv/sat/sat_u_trunc-6-u16.c -O3  check-function-bodies sat_u_trunc_uint32_t_to_uint8_t_fmt_4
+FAIL: gcc.target/riscv/sat/sat_u_trunc-6-u16.c -Ofast  check-function-bodies sat_u_trunc_uint32_t_to_uint8_t_fmt_4
+FAIL: gcc.target/riscv/sat/sat_u_trunc-6-u16.c -Os  check-function-bodies sat_u_trunc_uint32_t_to_uint8_t_fmt_4
+FAIL: gcc.target/riscv/sat/sat_u_trunc-6-u16.c -Oz  check-function-bodies sat_u_trunc_uint32_t_to_uint8_t_fmt_4
+FAIL: gcc.target/riscv/rvv/autovec/poly_licm-1.c -O3 -ftree-vectorize  scan-assembler-times vid\\.v\\s+v[0-9]+\\s+addi\\s+\\s*[a-x0-9]+,\\s*[a-x0-9]+,\\s*-1\\s+vrsub\\.vx\\s+ 1
+FAIL: gcc.target/riscv/rvv/autovec/pr121510.c -O3 -ftree-vectorize (test for excess errors)
+FAIL: gcc.target/riscv/rvv/autovec/pr121742.c -O3 -ftree-vectorize (test for excess errors)
+UNRESOLVED: gcc.target/riscv/rvv/autovec/pr121742.c -O3 -ftree-vectorize compilation failed to produce executable
+FAIL: gcc.target/riscv/rvv/autovec/pr121780.c -O3 -ftree-vectorize (test for excess errors)
+UNRESOLVED: gcc.target/riscv/rvv/autovec/pr121780.c -O3 -ftree-vectorize compilation failed to produce executable
+FAIL: gcc.target/riscv/rvv/autovec/pr121781.c -O3 -ftree-vectorize (test for excess errors)
+UNRESOLVED: gcc.target/riscv/rvv/autovec/pr121781.c -O3 -ftree-vectorize compilation failed to produce executable
+FAIL: gcc.target/riscv/rvv/autovec/pr121845.c -O3 -ftree-vectorize (test for excess errors)
+UNRESOLVED: gcc.target/riscv/rvv/autovec/pr121845.c -O3 -ftree-vectorize compilation failed to produce executable
+FAIL: gcc.target/riscv/rvv/autovec/pr123910.c -O3 -ftree-vectorize (test for excess errors)
+FAIL: gcc.target/riscv/rvv/autovec/pr123940.c -O3 -ftree-vectorize (test for excess errors)
+UNRESOLVED: gcc.target/riscv/rvv/autovec/pr123940.c -O3 -ftree-vectorize compilation failed to produce executable
+FAIL: gcc.target/riscv/rvv/base/pr122869.c (test for excess errors)
+UNRESOLVED: gcc.target/riscv/rvv/base/pr122869.c compilation failed to produce executable
+FAIL: gcc.target/riscv/rvv/xtheadvector/pr123971.c (test for excess errors)
+FAIL: gcc.target/riscv/rvv/xtheadvector/pr124147.c (test for excess errors)


### PR DESCRIPTION
GCC 15.2 has a libgomp issue, which blocks the update of glibc (see #1835). A bump GCC to the latest commit on the gcc-15 release branch, which includes a fix for this issue.