### PR TITLE
CI: introduce ccache to speed up builds

### DIFF
--- a/.github/setup-apt.sh
+++ b/.github/setup-apt.sh
@@ -5,6 +5,6 @@ apt update
 apt install -y autoconf automake autotools-dev curl python3 python3-pip \
             python3-tomli libmpc-dev libmpfr-dev libgmp-dev gawk \
             build-essential bison flex texinfo gperf libtool patchutils bc \
-            zlib1g-dev libexpat-dev git ninja-build cmake libglib2.0-dev \
+            zlib1g-dev libexpat-dev git ninja-build cmake ccache libglib2.0-dev \
             expect device-tree-compiler python3-pyelftools libslirp-dev \
             libzstd-dev libncurses-dev

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -127,6 +127,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: [submodule_cache,validate_inputs]
     env:
+      CCACHE_BASEDIR: ${{ github.workspace }}
+      CCACHE_COMPILERCHECK: content
+      CCACHE_DIR: /mnt/ccache
+      CCACHE_MAXSIZE: 2G
       smcache_key: ${{ needs.submodule_cache.outputs.key }}
     strategy:
       matrix:
@@ -156,11 +160,34 @@ jobs:
       - name: install dependencies
         run: sudo ./.github/setup-apt.sh
 
+      - name: Enable ccache compiler wrappers
+        run: echo "/usr/lib/ccache" >> "${GITHUB_PATH}"
+
+      - name: Prepare ccache directory
+        run: |
+          sudo mkdir -p "${CCACHE_DIR}"
+          sudo chown runner:runner "${CCACHE_DIR}"
+
+      - name: Restore ccache
+        id: ccache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-v1-${{ matrix.os }}-${{ github.run_id }}
+          restore-keys: |
+            ccache-v1-${{ matrix.os }}-
+
       - name: Load submodule cache
         uses: actions/cache/restore@v4
         with:
           path: ${{ env.submodule_paths }}
           key: ${{ env.smcache_key }}
+
+      - name: Initialize ccache
+        run: |
+          ccache -M "${CCACHE_MAXSIZE}"
+          ccache -z
+          ccache -s
 
       - name: build toolchain
         run: |
@@ -199,6 +226,24 @@ jobs:
           && matrix.report == true
         run: |
           make report-${{ matrix.mode }} -j $(nproc)
+
+      - name: Show ccache statistics
+        if: always()
+        run: ccache -s
+
+      - name: Save ccache
+        if: |
+          always()
+          && !cancelled()
+          && github.event_name != 'pull_request'
+          && matrix.mode == 'linux'
+          && matrix.target == 'rv64gc-lp64d'
+          && matrix.compiler == 'llvm'
+          && matrix.sim == ''
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-v1-${{ matrix.os }}-${{ github.run_id }}
 
       - name: generate prebuilt toolchain name
         id:   toolchain-name-generator

--- a/scripts/wrapper/spike/riscv64-unknown-linux-gnu-run
+++ b/scripts/wrapper/spike/riscv64-unknown-linux-gnu-run
@@ -4,10 +4,11 @@ xlen="$(march-to-cpu-opt --elf-file-path $1 --print-xlen)"
 isa="$(march-to-cpu-opt --elf-file-path $1 --print-spike-isa)"
 varch="$(march-to-cpu-opt --elf-file-path $1 --print-spike-varch)"
 
+[[ ${isa} != *_zicclsm* ]] && isa="${isa}_zicclsm"
+
 isa_option="--isa=${isa}"
 varch_option=""
-memory_option="--misaligned"
 
 [[ ! -z ${varch} ]] && varch_option="--varch=${varch}"
 
-spike ${memory_option} ${isa_option} ${varch_option} ${PK_PATH}/pk${xlen} "$@"
+spike ${isa_option} ${varch_option} ${PK_PATH}/pk${xlen} "$@"


### PR DESCRIPTION
The CI repeatedly rebuilds some parts of the toolchain with the host compiler: binutils, GCC, GDB, and QEMU.
We can use ccache to speed up rebuilding these parts.

Therefore, this PR introduces ccache to the CI builds:
  - install `ccache` as part of the CI build dependencies
  - restore and save a per-OS ccache directory in the reusable workflow
  - print ccache statistics before and after the build
  - limit the cache size to 1 GiB to keep runner disk usage limited
  - disable `ccache` while running `make build-llvm`

Note that we intentionally skip using ccache for LLVM for now.
The reason is to avoid cache thrashing.
The PR uses 1 GB of cache per OS, but if we exceed the cache too much, we may run into a disk space issue.
So, we can introduce ccache for LLVM in the future, if we have a better understanding of the cache behavior.