### PR TITLE
CI: bump workflows to Node 24 action majors

### DIFF
--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -98,7 +98,7 @@ jobs:
     outputs:
       key: ${{ steps.keygen.outputs.smcache_key }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Remove unneeded frameworks to recover disk space
         run: sudo ./.github/cleanup-rootfs.sh
@@ -109,7 +109,7 @@ jobs:
 
       - name: Setup submodule cache
         id: smcache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.submodule_paths }}
           key: ${{ steps.keygen.outputs.smcache_key }}
@@ -148,7 +148,7 @@ jobs:
     outputs:
       toolchain-name: ${{ steps.toolchain-name-generator.outputs.TOOLCHAIN_NAME }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Remove unneeded frameworks to recover disk space
         run: sudo ./.github/cleanup-rootfs.sh
@@ -157,7 +157,7 @@ jobs:
         run: sudo ./.github/setup-apt.sh
 
       - name: Load submodule cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ${{ env.submodule_paths }}
           key: ${{ env.smcache_key }}
@@ -248,12 +248,12 @@ jobs:
           du -s -h /mnt/riscv
           XZ_OPT="-e -T0" tar cJvf riscv-stripped.tar.xz -C /mnt/ riscv/
           mv riscv-stripped.tar.xz ${{ steps.toolchain-name-generator.outputs.TOOLCHAIN_NAME_STRIPPED }}.tar.xz
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: ${{ inputs.strip == 'unstripped' || inputs.strip == 'both' }}
         with:
           name: ${{ steps.toolchain-name-generator.outputs.TOOLCHAIN_NAME }}
           path: ${{ steps.toolchain-name-generator.outputs.TOOLCHAIN_NAME }}.tar.xz
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: ${{ inputs.strip == 'stripped' || inputs.strip == 'both' }}
         with:
           name: ${{ steps.toolchain-name-generator.outputs.TOOLCHAIN_NAME_STRIPPED }}

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       stale: ${{ steps.activity_check.outputs.stale }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name:  Activity check
         id: activity_check
         run:   |
@@ -76,7 +76,7 @@ jobs:
           echo "dateword=$(date --utc '+%B %d, %Y')" >> $GITHUB_OUTPUT
         shell: bash
       - name: Download Built Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: ${{ env.ARTIFACTS_DIR }}
           merge-multiple: true
@@ -87,7 +87,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.metadata.outputs.datestamp }}
           name: "Nightly: ${{ steps.metadata.outputs.dateword }}"


### PR DESCRIPTION
Update checkout and cache to their first Node 24-capable majors and move the other JavaScript actions in the same workflows to Node 24-capable lines as well.

GitHub's docs say checkout v5 and cache v5 run on Node 24 and require Actions Runner v2.327.1 or newer. GitHub's changelog also says JavaScript actions will switch to Node 24 by default on June 2, 2026.

Refs:
https://github.com/actions/checkout/releases/tag/v5.0.0 https://github.com/actions/cache
https://github.com/actions/upload-artifact/releases/tag/v6.0.0 https://github.com/actions/download-artifact/releases/tag/v7.0.0 GitHub Changelog: Deprecation of Node 20 on GitHub Actions runners

This removes the current warnings for checkout and cache and avoids leaving the same workflows on other Node 20-based action majors.