### PR TITLE
Bump Spike to latest commit

### DIFF
--- a/scripts/wrapper/spike/riscv64-unknown-linux-gnu-run
+++ b/scripts/wrapper/spike/riscv64-unknown-linux-gnu-run
@@ -4,10 +4,11 @@ xlen="$(march-to-cpu-opt --elf-file-path $1 --print-xlen)"
 isa="$(march-to-cpu-opt --elf-file-path $1 --print-spike-isa)"
 varch="$(march-to-cpu-opt --elf-file-path $1 --print-spike-varch)"
 
+[[ ${isa} != *_zicclsm* ]] && isa="${isa}_zicclsm"
+
 isa_option="--isa=${isa}"
 varch_option=""
-memory_option="--misaligned"
 
 [[ ! -z ${varch} ]] && varch_option="--varch=${varch}"
 
-spike ${memory_option} ${isa_option} ${varch_option} ${PK_PATH}/pk${xlen} "$@"
+spike ${isa_option} ${varch_option} ${PK_PATH}/pk${xlen} "$@"


### PR DESCRIPTION
Let's update Spike to the latest upstream commit.

Related to https://github.com/riscv-collab/riscv-gnu-toolchain/pull/1852.