### PR TITLE
ci: update GitHub Actions cache and artifact actions

### DIFF
--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -170,7 +170,7 @@ jobs:
 
       - name: Restore ccache
         id: ccache-restore
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-v1-${{ matrix.os }}-${{ github.run_id }}
@@ -240,7 +240,7 @@ jobs:
           && matrix.target == 'rv64gc-lp64d'
           && matrix.compiler == 'llvm'
           && matrix.sim == ''
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-v1-${{ matrix.os }}-${{ github.run_id }}

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -98,7 +98,7 @@ jobs:
     outputs:
       key: ${{ steps.keygen.outputs.smcache_key }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Remove unneeded frameworks to recover disk space
         run: sudo ./.github/cleanup-rootfs.sh
@@ -152,7 +152,7 @@ jobs:
     outputs:
       toolchain-name: ${{ steps.toolchain-name-generator.outputs.TOOLCHAIN_NAME }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Remove unneeded frameworks to recover disk space
         run: sudo ./.github/cleanup-rootfs.sh
@@ -296,13 +296,13 @@ jobs:
           du -s -h /mnt/riscv
           XZ_OPT="-e -T0" tar cJvf riscv-stripped.tar.xz -C /mnt/ riscv/
           mv riscv-stripped.tar.xz ${{ steps.toolchain-name-generator.outputs.TOOLCHAIN_NAME_STRIPPED }}.tar.xz
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         if: ${{ inputs.strip == 'unstripped' || inputs.strip == 'both' }}
         with:
           name: ${{ steps.toolchain-name-generator.outputs.TOOLCHAIN_NAME }}
           path: ${{ steps.toolchain-name-generator.outputs.TOOLCHAIN_NAME }}.tar.xz
           compression-level: 0
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         if: ${{ inputs.strip == 'stripped' || inputs.strip == 'both' }}
         with:
           name: ${{ steps.toolchain-name-generator.outputs.TOOLCHAIN_NAME_STRIPPED }}

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       stale: ${{ steps.activity_check.outputs.stale }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name:  Activity check
         id: activity_check
         run:   |
@@ -76,7 +76,7 @@ jobs:
           echo "dateword=$(date --utc '+%B %d, %Y')" >> $GITHUB_OUTPUT
         shell: bash
       - name: Download Built Artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           path: ${{ env.ARTIFACTS_DIR }}
           merge-multiple: true


### PR DESCRIPTION
Update the GitHub Actions workflows to remove the remaining Node 20-based cache action usage and align the other first-party actions with their current major versions.

Changes:

  - bump `actions/cache/restore` from `v4` to `v5`
  - bump `actions/cache/save` from `v4` to `v5`
  - bump `actions/checkout` from `v5` to `v6`
  - bump `actions/upload-artifact` from `v6` to `v7`
  - bump `actions/download-artifact` from `v7` to `v8`

Note, that we somehow missed these in https://github.com/riscv-collab/riscv-gnu-toolchain/pull/1853.

References:

  - `actions/cache`: https://github.com/actions/cache
  - `actions/checkout`: https://github.com/actions/checkout
  - `actions/upload-artifact`: https://github.com/actions/upload-artifact
  - `actions/download-artifact`: https://github.com/actions/download-artifact
  - GitHub changelog:
    https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
