### PR TITLE
CI/CD: Add medany and large code model to multilib

### DIFF
--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -200,7 +200,7 @@ jobs:
           TARGET_TUPLE=($(echo ${{ matrix.target }} | tr "-" "\n"))
           BUILD_TOOLCHAIN="./configure --prefix=/mnt/riscv --with-arch=${TARGET_TUPLE[0]} --with-abi=${TARGET_TUPLE[1]}"
           ARGS=""
-          if [ "${{ matrix.mode }}" == "newlib" ] && [ -n "${{ matrix.baremetal-multilib }}" ]; then # build toolchain with newlib
+          if [ "${{ matrix.mode }}" == "newlib" ] && [ "${{ matrix.compiler }}" != "llvm" ] && [ -n "${{ matrix.baremetal-multilib }}" ]; then
             ARGS="$ARGS --with-multilib-generator=\"${{ matrix.baremetal-multilib }}\""
           fi
           if [ "${{ matrix.compiler }}" == "llvm" ]; then # build toolchain with llvm

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -46,6 +46,10 @@ on:
         description: "Build simulator and include in the toolchain"
         type: boolean
         default: false
+      baremetal-multilib:
+        description: "Whether to build multi-lib for baremetal (newlib) mode"
+        type: string
+        default: "rv32i-ilp32--c;rv32im-ilp32--c;rv32iac-ilp32--;rv32imac-ilp32--;rv32imafc-ilp32f-rv32imafdc-;rv64imac-lp64--;rv64imafdc-lp64d--;--cmodel;medany,large"
 
 env:
   submodule_paths: |
@@ -145,6 +149,8 @@ jobs:
           - ${{ inputs.report }}
         build-sim:
           - ${{ inputs.build-sim }}
+        baremetal-multilib:
+          - ${{ inputs.baremetal-multilib }}
 
         exclude:
           - mode: uclibc
@@ -194,6 +200,9 @@ jobs:
           TARGET_TUPLE=($(echo ${{ matrix.target }} | tr "-" "\n"))
           BUILD_TOOLCHAIN="./configure --prefix=/mnt/riscv --with-arch=${TARGET_TUPLE[0]} --with-abi=${TARGET_TUPLE[1]}"
           ARGS=""
+          if [ "${{ matrix.mode }}" == "newlib" ] && [ -n "${{ matrix.baremetal-multilib }}" ]; then # build toolchain with newlib
+            ARGS="$ARGS --with-multilib-generator=\"${{ matrix.baremetal-multilib }}\""
+          fi
           if [ "${{ matrix.compiler }}" == "llvm" ]; then # build toolchain with llvm
             ARGS="$ARGS --enable-llvm"
           fi


### PR DESCRIPTION
NOTE: LLVM does not support multilib, so skip --with-multilib-generator
when compiler is llvm, this will result in the released toolchain package containing LLVM not including multilib generators with different code models.