### PR TITLE
ci: Fix dejagnu submodule checkout with shallow clone

### DIFF
--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -116,7 +116,9 @@ jobs:
 
       - name: Checkout required submodules
         if: steps.smcache.outputs.cache-hit != 'true'
-        run: git submodule update --init -j $(nproc) --depth 1 $(echo ${submodule_paths} | sed '$d' | tr '\n' ' ')
+        run: |
+          git submodule update --init dejagnu
+          git submodule update --init -j $(nproc) --depth 1 $(git submodule | awk '$2 != "dejagnu" {print $2}')
 
       - name: Storage size optimization
         if: steps.smcache.outputs.cache-hit != 'true'

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,7 +16,7 @@
 	path = dejagnu
 	url = https://git.savannah.gnu.org/git/dejagnu.git
 	branch = master
-	shallow = true
+	shallow = false
 [submodule "newlib"]
 	path = newlib
 	url = https://sourceware.org/git/newlib-cygwin.git


### PR DESCRIPTION
The dejagnu submodule is pinned to a commit that is neither a tag nor a branch HEAD. Git's shallow clone protocol only advertises tags and branch tips, so --depth 1 fails with "unadvertised object" for dejagnu.

Set shallow = false for dejagnu in .gitmodules and clone it fully, then clone all other submodules with --depth 1 as before.