### PR TITLE
build: Fix cmodel handling when multilib-generator uses --cmodel 

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -148,6 +148,7 @@ GCC_MULTILIB_FLAGS := $(MULTILIB_FLAGS) --with-multilib-generator="$(MULTILIB_GE
 endif
 GLIBC_MULTILIB_NAMES := @glibc_multilib_names@
 GCC_CHECKING_FLAGS := @gcc_checking@
+GCC_WITH_SPECS := @gcc_with_specs@
 
 EXTRA_MULTILIB_TEST := @extra_multilib_test@
 
@@ -166,9 +167,20 @@ NEWLIB_TUPLE ?= $(call make_tuple,$(XLEN),elf)
 MUSL_TUPLE ?= $(call make_tuple,$(XLEN),linux-musl)
 UCLIBC_TUPLE ?= $(call make_tuple,$(XLEN),linux-uclibc)
 
+# When MULTILIB_GEN specifies code model variants (--cmodel), omit the global
+# cmodel flag so GCC's multilib mechanism can set the correct -mcmodel per
+# variant. Without this, -mcmodel=medlow in CFLAGS_FOR_TARGET overrides the
+# per-variant flag GCC passes internally, causing crtbegin.o to always be compiled
+# with medlow even in medany/large multilib directories.
+ifneq (,$(findstring --cmodel,$(MULTILIB_GEN)))
+CFLAGS_FOR_TARGET := $(CFLAGS_FOR_TARGET_EXTRA) $(DEBUG_INFO) @target_cflags@
+CXXFLAGS_FOR_TARGET := $(CXXFLAGS_FOR_TARGET_EXTRA) $(DEBUG_INFO) @target_cxxflags@
+ASFLAGS_FOR_TARGET := $(ASFLAGS_FOR_TARGET_EXTRA) $(DEBUG_INFO)
+else
 CFLAGS_FOR_TARGET := $(CFLAGS_FOR_TARGET_EXTRA) $(DEBUG_INFO) @target_cflags@ @cmodel@
 CXXFLAGS_FOR_TARGET := $(CXXFLAGS_FOR_TARGET_EXTRA) $(DEBUG_INFO) @target_cxxflags@ @cmodel@
 ASFLAGS_FOR_TARGET := $(ASFLAGS_FOR_TARGET_EXTRA) $(DEBUG_INFO) @cmodel@
+endif
 LLVM_TARGET_ARCH := $(patsubst --with-arch=%,%,$(WITH_ARCH))
 LLVM_TARGET_ABI := $(patsubst --with-abi=%,%,$(WITH_ABI))
 LLVM_TARGET_TUNE := $(patsubst --with-tune=%,%,$(WITH_TUNE))
@@ -621,6 +633,7 @@ stamps/build-gcc-linux-stage2: $(GCC_SRCDIR) $(GCC_SRC_GIT) $(addprefix stamps/b
 		$(WITH_ARCH) \
 		$(WITH_TUNE) \
 		$(WITH_ISA_SPEC) \
+		$(GCC_WITH_SPECS) \
 		$(GCC_EXTRA_CONFIGURE_FLAGS) \
 		CFLAGS_FOR_TARGET="-O2 $(CFLAGS_FOR_TARGET)" \
 		CXXFLAGS_FOR_TARGET="-O2 $(CXXFLAGS_FOR_TARGET)"
@@ -872,6 +885,7 @@ stamps/build-gcc-newlib-stage2: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-newlib
 		$(WITH_ARCH) \
 		$(WITH_TUNE) \
 		$(WITH_ISA_SPEC) \
+		$(GCC_WITH_SPECS) \
 		$(GCC_EXTRA_CONFIGURE_FLAGS) \
 		CFLAGS_FOR_TARGET="-Os $(CFLAGS_FOR_TARGET)" \
 		CXXFLAGS_FOR_TARGET="-Os $(CXXFLAGS_FOR_TARGET)"
@@ -1034,6 +1048,7 @@ stamps/build-gcc-musl-stage2: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-musl-lin
 		$(WITH_ARCH) \
 		$(WITH_TUNE) \
 		$(WITH_ISA_SPEC) \
+		$(GCC_WITH_SPECS) \
 		$(GCC_EXTRA_CONFIGURE_FLAGS) \
 		CFLAGS_FOR_TARGET="-O2 $(CFLAGS_FOR_TARGET)" \
 		CXXFLAGS_FOR_TARGET="-O2 $(CXXFLAGS_FOR_TARGET)"
@@ -1169,6 +1184,7 @@ stamps/build-gcc-uclibc-stage2: $(GCC_SRCDIR) $(GCC_SRC_GIT) stamps/build-uclibc
 		$(WITH_ARCH) \
 		$(WITH_TUNE) \
 		$(WITH_ISA_SPEC) \
+		$(GCC_WITH_SPECS) \
 		$(GCC_EXTRA_CONFIGURE_FLAGS) \
 		CFLAGS_FOR_TARGET="-O2 $(CFLAGS_FOR_TARGET)" \
 		CXXFLAGS_FOR_TARGET="-O2 $(CXXFLAGS_FOR_TARGET)"

--- a/configure
+++ b/configure
@@ -641,6 +641,7 @@ configure_host
 target_cxxflags
 target_cflags
 cmodel
+gcc_with_specs
 endian
 gcc_checking
 musl_multilib_names
@@ -1426,8 +1427,11 @@ Optional Packages:
                           set can work/compatible with existing multi-libs,
                           format: <arch>-<abi>;<arch>-<abi> e.g:
                           --with-extra-multilib-test="rv64gcv-lp64;rv64gcv_zba-lp64"
-  --with-cmodel           Select the code model to use when building libc and
-                          libgcc [--with-cmodel=medlow]
+  --with-cmodel           Set the default code model. Sets the GCC driver
+                          default via --with-specs and, when
+                          --with-multilib-generator does not specify --cmodel
+                          variants, also sets CFLAGS_FOR_TARGET.
+                          [--with-cmodel=medlow]
   --with-endian           Select the target endianess [--with-endian=little]
   --with-target-cflags    Add extra target flags for C for library code
   --with-target-cxxflags  Add extra target flags for C++ for library code
@@ -4216,9 +4220,11 @@ fi
 if test "x$with_cmodel" != xno
 then :
   cmodel=-mcmodel=$with_cmodel
+  gcc_with_specs="--with-specs='%{!mcmodel*:-mcmodel=$with_cmodel}'"
 
 else $as_nop
   cmodel=-mcmodel=medlow
+  gcc_with_specs="--with-specs='%{!mcmodel*:-mcmodel=medlow}'"
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -179,14 +179,16 @@ AS_IF([test "x$enable_gcc_checking" = xyes],
 
 AC_ARG_WITH(cmodel,
 	[AS_HELP_STRING([--with-cmodel],
-		[Select the code model to use when building libc and libgcc @<:@--with-cmodel=medlow@:>@])],
+		[Set the default code model. Sets the GCC driver default via --with-specs and, when --with-multilib-generator does not specify --cmodel variants, also sets CFLAGS_FOR_TARGET. @<:@--with-cmodel=medlow@:>@])],
 	[],
 	[with_cmodel=no]
 	)
 
 AS_IF([test "x$with_cmodel" != xno],
-	[AC_SUBST(cmodel, -mcmodel=$with_cmodel)],
-	[AC_SUBST(cmodel, -mcmodel=medlow)])
+	[AC_SUBST(cmodel, -mcmodel=$with_cmodel)
+	 AC_SUBST(gcc_with_specs, "--with-specs='%{!mcmodel*:-mcmodel=$with_cmodel}'")],
+	[AC_SUBST(cmodel, -mcmodel=medlow)
+	 AC_SUBST(gcc_with_specs, "--with-specs='%{!mcmodel*:-mcmodel=medlow}'")])
 
 AS_IF([test "x$with_endian" != x],
 	[AC_SUBST(endian, endian=$with_endian)],


### PR DESCRIPTION
Previously, --with-cmodel affected the GCC driver's default code model
indirectly: @cmodel@ was injected into CFLAGS_FOR_TARGET

When --with-multilib-generator specifies --cmodel variants, that same
@cmodel@ in CFLAGS_FOR_TARGET overrides the per-variant -mcmodel that
GCC's multilib mechanism selects internally, causing crtbegin.o to
always be compiled with the global model (e.g. medlow) even
in medany/large multilib directories.

This patch changes the approach:

- When MULTILIB_GEN contains --cmodel, omit @cmodel@ from
  *FLAGS_FOR_TARGET so the multilib mechanism controls -mcmodel per
  variant without interference. In the non-multilib case, @cmodel@
  is still passed via CFLAGS_FOR_TARGET as before, because stage1 GCC
  (which compiles newlib/glibc/musl) does not have --with-specs and
  relies on CFLAGS_FOR_TARGET for the correct code model.

- Introduce --with-specs=%{!mcmodel*:-mcmodel=X} to set the GCC
  driver's default code model directly and explicitly. This replaces
  the previous indirect effect via CFLAGS_FOR_TARGET. gcc_with_specs
  is always set (defaulting to medlow when --with-cmodel is not
  specified).

Apply GCC_WITH_SPECS to all GCC stage2 configure invocations
(newlib, linux, musl, uclibc) so --with-cmodel has consistent driver
default semantics across all toolchain variants.