### PR TITLE
Makefile.in: switch OpenMP build to runtimes mode

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -27,8 +27,10 @@ LLVM_LINUX_COMMON_CMAKE_FLAGS = \
 define LLVM_BUILD_OPENMP
 	if test $(XLEN) -eq 64; then \
 	    mkdir $(notdir $@)/openmp-shared; \
-	    cmake -S$(LLVM_SRCDIR)/openmp \
+	    cmake -S$(LLVM_SRCDIR)/runtimes \
 	        -B$(notdir $@)/openmp-shared \
+	        -DLLVM_ENABLE_RUNTIMES=openmp \
+	        -DLLVM_DEFAULT_TARGET_TRIPLE=$(1) \
 	        -DCMAKE_INSTALL_PREFIX=$(SYSROOT) \
 	        -DCMAKE_C_COMPILER=$(LLVM_CC_FOR_TARGET) \
 	        -DCMAKE_CXX_COMPILER=$(LLVM_CXX_FOR_TARGET) \
@@ -49,8 +51,10 @@ define LLVM_BUILD_OPENMP
 	    $(MAKE) -C $(notdir $@)/openmp-shared; \
 	    $(MAKE) -C $(notdir $@)/openmp-shared install; \
 	    mkdir $(notdir $@)/openmp-static; \
-	    cmake -S$(LLVM_SRCDIR)/openmp \
+	    cmake -S$(LLVM_SRCDIR)/runtimes \
 	        -B$(notdir $@)/openmp-static \
+	        -DLLVM_ENABLE_RUNTIMES=openmp \
+	        -DLLVM_DEFAULT_TARGET_TRIPLE=$(1) \
 	        -DCMAKE_INSTALL_PREFIX=$(SYSROOT) \
 	        -DCMAKE_C_COMPILER=$(LLVM_CC_FOR_TARGET) \
 	        -DCMAKE_CXX_COMPILER=$(LLVM_CXX_FOR_TARGET) \
@@ -1259,7 +1263,7 @@ stamps/build-llvm-linux: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) $(BINUTILS_SRCDIR) $(BIN
 	    $(LLVM_EXTRA_CONFIGURE_FLAGS)
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) $(subst -,/,$(INSTALL_TARGET))
-	$(LLVM_BUILD_OPENMP)
+	$(call LLVM_BUILD_OPENMP,$(LINUX_TUPLE))
 	cp $(notdir $@)/lib/$(LINUX_TUPLE)/libc++* $(SYSROOT)/lib
 	cp $(notdir $@)/lib/$(LINUX_TUPLE)/libunwind* $(SYSROOT)/lib
 	cd $(INSTALL_DIR)/bin && ln -s -f clang $(LINUX_TUPLE)-clang && ln -s -f clang++ $(LINUX_TUPLE)-clang++
@@ -1280,7 +1284,7 @@ stamps/build-llvm-musl: $(LLVM_SRCDIR) $(LLVM_SRC_GIT) $(BINUTILS_SRCDIR) $(BINU
 	    $(LLVM_EXTRA_CONFIGURE_FLAGS)
 	$(MAKE) -C $(notdir $@)
 	$(MAKE) -C $(notdir $@) $(subst -,/,$(INSTALL_TARGET))
-	$(LLVM_BUILD_OPENMP)
+	$(call LLVM_BUILD_OPENMP,$(MUSL_TUPLE))
 	cp $(notdir $@)/lib/$(MUSL_TUPLE)/libc++* $(SYSROOT)/lib
 	cp $(notdir $@)/lib/$(MUSL_TUPLE)/libunwind* $(SYSROOT)/lib
 	cd $(INSTALL_DIR)/bin && ln -s -f clang $(MUSL_TUPLE)-clang && ln -s -f clang++ $(MUSL_TUPLE)-clang++


### PR DESCRIPTION
The LLVM_BUILD_OPENMP macro used the standalone path (-S openmp), which has been removed in recent LLVM (llvm/llvm-project commit 6295b8e). Switch to the runtimes path (-S runtimes -DLLVM_ENABLE_RUNTIMES=openmp).